### PR TITLE
fix: `EnumInt` intrinsic to return `Int32`

### DIFF
--- a/compiler/src/scope.rs
+++ b/compiler/src/scope.rs
@@ -504,7 +504,7 @@ impl Scope {
             (IntrinsicOp::ArrayErase, _) => TypeId::Void,
             (IntrinsicOp::ArrayLast, TypeId::Array(_, member)) => *member,
             (IntrinsicOp::ToString, _) => self.resolve_type(Ident::new("String".to_owned()), pool)?,
-            (IntrinsicOp::EnumInt, _) => self.resolve_type(Ident::new("Uint32".to_owned()), pool)?,
+            (IntrinsicOp::EnumInt, _) => self.resolve_type(Ident::new("Int32".to_owned()), pool)?,
             (IntrinsicOp::IntEnum, _) => panic!(),
             (IntrinsicOp::ToVariant, _) => self.resolve_type(Ident::new("Variant".to_owned()), pool)?,
             (IntrinsicOp::FromVariant, _) => panic!(),


### PR DESCRIPTION
World's tiniest PR, fixing an issue introduced in d3179183a09bd31f51ba480ba833cb78c987d270 where `EnumInt(...)` was resolving to `UInt32`.