### PR TITLE
Add github workflows for CI and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            target/release/scc.exe
+            target/release/redscript-cli.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all-features
+      - name: Create zip of result
+        run: |
+          7z a -mx=9 release.zip ./target/release/scc.exe ./target/release/redscript-cli.exe
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release.zip
+          asset_name: release-${{ github.event.release.tag_name }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
### `.github/workflows/ci.yml`

Runs a release build and publishes the artifact (only available through Actions tab in repository). Ensures that branches will always have a release-ready state, at least in terms of compiling. Could and should be extended to include linting, but unsure how this is handled in rust and what conventions exist - I did notice `.rustfmt.toml` though.

Will run on **every** push and pull_request, regardless of branch. Without a convention where production code lives and where development occurs, this is just my best guess but not optimal. Free github accounts have limited build resources, so this could end up being queued for a long-ish time. I would propose to define development flow based on git-flow, but that's a different topic.

It currently runs on the `windows-latest` github environment so the archived artifacts can be downloaded and tested, but it could also run on `ubuntu-latest`. Running it on `ubuntu-latest` is much faster, but the artifacts are not as useful. Still there's the value of compile status and linting status (and maybe running tests) which is the main focus of continuous integration. This can easily be changed, so I just left it as is.

### `.github/workflows/release.yml`

Runs only when a (non-pre) release is created through github and then builds, zips up the executables, finally attaches the result to the triggering release. An example result for this is: https://github.com/fre-sch/redscript/releases/tag/v0.0.1r

For `fre-sch/redscript/releases/tag/v0.0.1r` I used github Release page to create and publish the release `v0.0.1r`, which then resulted in build https://github.com/fre-sch/redscript/runs/1790523991?check_suite_focus=true which then automatically uploaded/attached the resulting archive.

Since github can create releases for any branch (like `feature/github-actions` in this case), this also doesn't assume any particular development flow, but does require picking the "right" branch when creating releases.

I've bundled the executables into a zip for easier attach to release, and also to include the release version name. That way, downloading doesn't result in `scc (1).exe`, `scc (2).exe`, `scc (3).exe` etc, but in `release-v0.0.1.zip`, `release-v0.0.2.zip`, `release-v0.0.3.zip`. This helps users track their downloaded versions and avoids confusion.

