### PR TITLE
Infer correct type from context

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -68,10 +68,19 @@ fn compile(opts: CompileOpts) -> Result<(), Error> {
     let mut bundle: ScriptBundle = ScriptBundle::load(&mut BufReader::new(File::open(opts.bundle)?))?;
     let mut compiler = Compiler::new(&mut bundle.pool)?;
 
-    compiler.compile(entries)?;
-    bundle.save(&mut BufWriter::new(File::create(&opts.output)?))?;
-
-    println!("Output successfully saved to {:?}", opts.output);
+    match compiler.compile(entries) {
+        Ok(()) => {
+            bundle.save(&mut BufWriter::new(File::create(&opts.output)?))?;
+            println!("Output successfully saved to {:?}", opts.output);
+        }
+        Err(Error::CompileError(err)) => {
+            println!("{}", err)
+        }
+        Err(Error::FunctionResolutionError(err)) => {
+            println!("{}", err)
+        }
+        Err(other) => Err(other)?,
+    }
     Ok(())
 }
 

--- a/compiler/src/assembler.rs
+++ b/compiler/src/assembler.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use redscript::ast::{Expr, Ident, LiteralType, Seq};
 use redscript::bundle::{ConstantPool, PoolIndex};
 use redscript::bytecode::{Instr, Offset};
-use redscript::definition::{Definition, Local, LocalFlags, ParameterFlags};
+use redscript::definition::{Definition, Local, LocalFlags, ParameterFlags, Type};
 use redscript::error::Error;
 use strum::{Display, EnumString};
 
@@ -48,7 +48,13 @@ impl Assembler {
         self.locals.append(code.locals);
     }
 
-    fn compile(&mut self, expr: &Expr, pool: &mut ConstantPool, scope: &mut Scope) -> Result<(), Error> {
+    fn compile(
+        &mut self,
+        expr: &Expr,
+        expected: Option<&TypeId>,
+        pool: &mut ConstantPool,
+        scope: &mut Scope,
+    ) -> Result<(), Error> {
         match expr {
             Expr::Ident(name) => {
                 match scope.resolve_reference(name.clone())? {
@@ -81,10 +87,16 @@ impl Assembler {
             Expr::UintLit(val) => {
                 self.emit(Instr::U32Const(*val as u32));
             }
-            Expr::Cast(type_, expr) => {
-                let type_idx = scope.resolve_type_index(Ident::new(type_.repr()))?;
-                self.emit(Instr::DynamicCast(type_idx, 0));
-                self.compile(expr, pool, scope)?;
+            Expr::Cast(type_name, expr) => {
+                let type_ = scope.resolve_type(type_name, pool)?;
+                let new_type = match scope.infer_type(&expr, None, pool)? {
+                    TypeId::Ref(_) => TypeId::Ref(Box::new(type_)),
+                    TypeId::WeakRef(_) => TypeId::WeakRef(Box::new(type_)),
+                    TypeId::ScriptRef(_) => TypeId::ScriptRef(Box::new(type_)),
+                    _ => type_,
+                };
+                self.emit(Instr::DynamicCast(scope.get_type_index(&new_type, pool)?, 0));
+                self.compile(expr, None, pool, scope)?;
             }
             Expr::Declare(name, type_, init) => {
                 let name_idx = pool.names.add(name.0.deref().to_owned());
@@ -92,51 +104,52 @@ impl Assembler {
                     (None, None) => Err(Error::CompileError(
                         "Type or initializer require on let binding".to_owned(),
                     ))?,
-                    (None, Some(val)) => (scope.infer_type(val, pool)?, Conversion::Identity),
-                    (Some(type_name), None) => (
-                        scope.resolve_type(Ident::new(type_name.repr()), pool)?,
-                        Conversion::Identity,
-                    ),
+                    (None, Some(val)) => (scope.infer_type(val, None, pool)?, Conversion::Identity),
+                    (Some(type_name), None) => (scope.resolve_type(type_name, pool)?, Conversion::Identity),
                     (Some(type_name), Some(val)) => {
-                        let val_type = scope.infer_type(val, pool)?;
-                        let type_ = scope.resolve_type(Ident::new(type_name.repr()), pool)?;
+                        let type_ = scope.resolve_type(type_name, pool)?;
+                        let val_type = scope.infer_type(val, Some(&type_), pool)?;
                         let conv = scope.convert_type(&val_type, &type_, pool)?;
                         (type_, conv)
                     }
                 };
-                let local = Local::new(type_.index().unwrap(), LocalFlags::new());
-                let idx = pool.push_definition(Definition::local(name_idx, scope.function.unwrap().cast(), local));
-                self.locals.push_back(idx.cast());
-                scope.push_local(name.clone(), idx.cast());
+                let local = Local::new(scope.get_type_index(&type_, pool)?, LocalFlags::new());
+                let idx = pool
+                    .push_definition(Definition::local(name_idx, scope.function.unwrap().cast(), local))
+                    .cast();
+                self.locals.push_back(idx);
+                scope.push_local(name.clone(), idx);
                 if let Some(val) = init {
                     self.emit(Instr::Assign);
-                    self.emit(Instr::Local(idx.cast()));
+                    self.emit(Instr::Local(idx));
                     self.compile_conversion(conversion);
-                    self.compile(val, pool, scope)?;
+                    self.compile(val, Some(&type_), pool, scope)?;
                 }
             }
             Expr::Assign(lhs, rhs) => {
-                let conv = scope.convert_expr(&rhs, &lhs, pool)?;
+                let lhs_type = scope.infer_type(lhs, None, pool)?;
+                let rhs_type = scope.infer_type(rhs, Some(&lhs_type), pool)?;
+                let conv = scope.convert_type(&rhs_type, &lhs_type, pool)?;
                 self.emit(Instr::Assign);
-                self.compile(lhs, pool, scope)?;
+                self.compile(lhs, None, pool, scope)?;
                 self.compile_conversion(conv);
-                self.compile(rhs, pool, scope)?;
+                self.compile(rhs, Some(&lhs_type), pool, scope)?;
             }
             Expr::ArrayElem(expr, idx) => {
-                match scope.infer_type(expr, pool)? {
-                    TypeId::Array(type_, _) => {
-                        self.emit(Instr::ArrayElement(type_));
+                match scope.infer_type(expr, None, pool)? {
+                    type_ @ TypeId::Array(_) => {
+                        self.emit(Instr::ArrayElement(scope.get_type_index(&type_, pool)?));
                     }
-                    TypeId::StaticArray(type_, _, _) => {
-                        self.emit(Instr::StaticArrayElement(type_));
+                    type_ @ TypeId::StaticArray(_, _) => {
+                        self.emit(Instr::StaticArrayElement(scope.get_type_index(&type_, pool)?));
                     }
                     other => {
                         let error = format!("Array access not allowed on {}", other.pretty(pool)?);
                         Err(Error::CompileError(error))?
                     }
                 }
-                self.compile(expr, pool, scope)?;
-                self.compile(idx, pool, scope)?;
+                self.compile(expr, None, pool, scope)?;
+                self.compile(idx, None, pool, scope)?;
             }
             Expr::New(name, args) => match scope.resolve_reference(name.clone())? {
                 Reference::Class(idx) => {
@@ -146,9 +159,12 @@ impl Assembler {
                             let err = format!("Expected {} parameters for {}", cls.fields.len(), name);
                             Err(Error::CompileError(err))?
                         }
+                        let fields = cls.fields.clone();
                         self.emit(Instr::Construct(args.len() as u8, idx));
-                        for arg in args {
-                            self.compile(arg, pool, scope)?;
+                        for (arg, field_idx) in args.iter().zip(fields) {
+                            let field = pool.field(field_idx)?;
+                            let field_type = scope.resolve_type_from_pool(field.type_, pool)?;
+                            self.compile(arg, Some(&field_type), pool, scope)?;
                         }
                     } else if args.is_empty() {
                         self.emit(Instr::New(idx));
@@ -162,12 +178,12 @@ impl Assembler {
             Expr::Return(Some(expr)) => {
                 let fun = pool.function(scope.function.unwrap())?;
                 if let Some(ret_type) = fun.return_type {
-                    let type_ = scope.infer_type(expr, pool)?;
-                    let expected = scope.resolve_type_by_index(ret_type, pool)?;
+                    let expected = scope.resolve_type_from_pool(ret_type, pool)?;
+                    let type_ = scope.infer_type(expr, Some(&expected), pool)?;
                     let conv = scope.convert_type(&type_, &expected, pool)?;
                     self.emit(Instr::Return);
                     self.compile_conversion(conv);
-                    self.compile(expr, pool, scope)?;
+                    self.compile(expr, Some(&expected), pool, scope)?;
                 } else {
                     Err(Error::CompileError(format!("Function should return nothing")))?
                 }
@@ -177,16 +193,16 @@ impl Assembler {
             }
             Expr::Seq(seq) => {
                 for expr in &seq.exprs {
-                    self.compile(expr, pool, scope)?;
+                    self.compile(expr, None, pool, scope)?;
                 }
             }
             Expr::Switch(expr, cases, default) => {
-                let type_ = scope.infer_type(expr, pool)?.index().unwrap();
-                let matched = Assembler::from_expr(expr, pool, scope)?;
-                self.emit(Instr::Switch(type_, matched.offset()));
+                let type_ = scope.infer_type(expr, None, pool)?;
+                let matched = Assembler::from_expr(expr, None, pool, scope)?;
+                self.emit(Instr::Switch(scope.get_type_index(&type_, pool)?, matched.offset()));
                 self.append(matched);
                 for case in cases {
-                    let matcher = Assembler::from_expr(&case.0, pool, &mut scope.clone())?;
+                    let matcher = Assembler::from_expr(&case.0, None, pool, &mut scope.clone())?;
                     let body = Assembler::from_seq(&case.1, pool, &mut scope.clone())?;
                     self.emit(Instr::SwitchLabel(matcher.offset(), matcher.offset() + body.offset()));
                     self.append(matcher);
@@ -198,11 +214,11 @@ impl Assembler {
                 }
             }
             Expr::If(cond, if_, else_) => {
-                let type_ = scope.infer_type(cond, pool)?;
-                let cond_code = Assembler::from_expr(cond, pool, &mut scope.clone())?;
+                let type_ = scope.infer_type(cond, None, pool)?;
+                let cond_code = Assembler::from_expr(cond, None, pool, &mut scope.clone())?;
                 let cond_code = match type_ {
-                    TypeId::Ref(_, _) => cond_code.prefix(Instr::RefToBool),
-                    TypeId::WeakRef(_, _) => cond_code.prefix(Instr::WeakRefToBool),
+                    TypeId::Ref(_) => cond_code.prefix(Instr::RefToBool),
+                    TypeId::WeakRef(_) => cond_code.prefix(Instr::WeakRefToBool),
                     _ => cond_code,
                 };
                 let mut if_branch = Assembler::from_seq(if_, pool, &mut scope.clone())?;
@@ -219,18 +235,18 @@ impl Assembler {
                 self.append(else_branch);
             }
             Expr::Conditional(cond, true_, false_) => {
-                let cond_code = Assembler::from_expr(cond, pool, scope)?;
-                let true_code = Assembler::from_expr(true_, pool, scope)?;
+                let cond_code = Assembler::from_expr(cond, None, pool, scope)?;
+                let true_code = Assembler::from_expr(true_, expected, pool, scope)?;
                 self.emit(Instr::Conditional(
                     cond_code.offset(),
                     cond_code.offset() + true_code.offset(),
                 ));
                 self.append(cond_code);
                 self.append(true_code);
-                self.compile(false_, pool, scope)?
+                self.compile(false_, expected, pool, scope)?
             }
             Expr::While(cond, body) => {
-                let cond_code = Assembler::from_expr(cond, pool, &mut scope.clone())?;
+                let cond_code = Assembler::from_expr(cond, None, pool, &mut scope.clone())?;
                 let mut body_code = Assembler::from_seq(body, pool, &mut scope.clone())?;
                 body_code.emit(Instr::Jump(-(cond_code.offset() + body_code.offset())));
 
@@ -238,21 +254,21 @@ impl Assembler {
                 self.append(cond_code);
                 self.append(body_code);
             }
-            Expr::Member(expr, ident) => match scope.infer_type(expr, pool)?.unwrapped() {
-                TypeId::Class(_, class) => {
-                    let object = Assembler::from_expr(expr, pool, scope)?;
+            Expr::Member(expr, ident) => match scope.infer_type(expr, None, pool)?.unwrapped() {
+                TypeId::Class(class) => {
+                    let object = Assembler::from_expr(expr, None, pool, scope)?;
                     let field = scope.resolve_field(ident.clone(), *class, pool)?;
                     let inner = Assembler::from_instr(Instr::ObjectField(field));
                     self.emit(Instr::Context(object.offset() + inner.offset()));
                     self.append(object);
                     self.append(inner)
                 }
-                TypeId::Struct(_, class) => {
+                TypeId::Struct(class) => {
                     let field = scope.resolve_field(ident.clone(), *class, pool)?;
                     self.emit(Instr::StructField(field));
-                    self.compile(expr, pool, scope)?;
+                    self.compile(expr, None, pool, scope)?;
                 }
-                TypeId::Enum(_, enum_) => {
+                TypeId::Enum(enum_) => {
                     let member_idx = scope.resolve_enum_member(ident.clone(), *enum_, pool)?;
                     self.emit(Instr::EnumConst(*enum_, member_idx));
                 }
@@ -265,27 +281,28 @@ impl Assembler {
                 if let Ok(intrinsic) = IntrinsicOp::from_str(&ident.0) {
                     self.compile_intrinsic(intrinsic, args, pool, scope)?;
                 } else {
-                    let match_ = scope.resolve_function(FunctionName::global(ident.clone()), args.iter(), pool)?;
+                    let match_ =
+                        scope.resolve_function(FunctionName::global(ident.clone()), args.iter(), expected, pool)?;
                     self.compile_call(match_, args.iter(), pool, scope)?;
                 }
             }
             Expr::MethodCall(expr, ident, args) => {
-                let type_ = scope.infer_type(expr, pool)?;
+                let type_ = scope.infer_type(expr, None, pool)?;
                 if let Some(Reference::Class(class)) = Self::get_static_reference(expr, scope) {
-                    let match_ = scope.resolve_method(ident.clone(), class, args, pool)?;
+                    let match_ = scope.resolve_method(ident.clone(), class, args, expected, pool)?;
                     let fun = pool.function(match_.index)?;
                     if fun.flags.is_static() {
                         self.compile_call(match_, args.iter(), pool, scope)?
                     } else {
                         Err(Error::CompileError(format!("Method {} is not static", ident)))?
                     }
-                } else if let TypeId::Class(_, class) = type_.unwrapped() {
-                    let object = if let TypeId::WeakRef(_, _) = type_ {
-                        Assembler::from_expr(expr, pool, scope)?.prefix(Instr::WeakRefToRef)
+                } else if let TypeId::Class(class) = type_.unwrapped() {
+                    let object = if let TypeId::WeakRef(_) = type_ {
+                        Assembler::from_expr(expr, None, pool, scope)?.prefix(Instr::WeakRefToRef)
                     } else {
-                        Assembler::from_expr(expr, pool, scope)?
+                        Assembler::from_expr(expr, None, pool, scope)?
                     };
-                    let fun = scope.resolve_method(ident.clone(), *class, args, pool)?;
+                    let fun = scope.resolve_method(ident.clone(), *class, args, expected, pool)?;
                     let mut inner = Assembler::new();
                     inner.compile_call(fun, args.iter(), pool, scope)?;
                     self.emit(Instr::Context(object.offset() + inner.offset()));
@@ -299,13 +316,13 @@ impl Assembler {
             Expr::BinOp(lhs, rhs, op) => {
                 let ident = Ident::new(op.name());
                 let args = iter::once(lhs.as_ref()).chain(iter::once(rhs.as_ref()));
-                let fun = scope.resolve_function(FunctionName::global(ident), args.clone(), pool)?;
+                let fun = scope.resolve_function(FunctionName::global(ident), args.clone(), expected, pool)?;
                 self.compile_call(fun, args, pool, scope)?;
             }
             Expr::UnOp(expr, op) => {
                 let ident = Ident::new(op.name());
                 let args = iter::once(expr.as_ref());
-                let fun = scope.resolve_function(FunctionName::global(ident), args.clone(), pool)?;
+                let fun = scope.resolve_function(FunctionName::global(ident), args.clone(), expected, pool)?;
                 self.compile_call(fun, args, pool, scope)?;
             }
             Expr::True => {
@@ -334,18 +351,22 @@ impl Assembler {
     ) -> Result<(), Error> {
         let fun = pool.function(function.index)?;
         let flags = fun.flags;
-        let params: Vec<ParameterFlags> = fun
+        let params: Vec<(ParameterFlags, PoolIndex<Type>)> = fun
             .parameters
             .iter()
-            .map(|idx| pool.parameter(*idx).unwrap().flags)
+            .map(|idx| {
+                let param = pool.parameter(*idx).unwrap();
+                (param.flags, param.type_)
+            })
             .collect();
         let name_idx = pool.definition(function.index)?.name;
 
         let mut args_code = Assembler::new();
-        for ((arg, conversion), flags) in args.zip(function.conversions).zip(params) {
+        for ((arg, conversion), (flags, type_idx)) in args.zip(function.conversions).zip(params) {
             let mut arg_code = Assembler::new();
             arg_code.compile_conversion(conversion);
-            arg_code.compile(arg, pool, scope)?;
+            let expected_type = scope.resolve_type_from_pool(type_idx, pool)?;
+            arg_code.compile(arg, Some(&expected_type), pool, scope)?;
             if flags.is_short_circuit() {
                 args_code.emit(Instr::Skip(arg_code.offset()));
             }
@@ -383,115 +404,116 @@ impl Assembler {
             let err = format!("Invalid number of arguments for {}", intrinsic);
             Err(Error::CompileError(err))?
         }
-        let type_ = scope.infer_type(&args[0], pool)?;
+        let type_ = scope.infer_type(&args[0], None, pool)?;
+        let type_idx = scope.get_type_index(&type_, pool)?;
         match (intrinsic, type_) {
-            (IntrinsicOp::Equals, type_) => {
-                self.emit(Instr::Equals(type_.index().unwrap()));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::Equals, _) => {
+                self.emit(Instr::Equals(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::NotEquals, type_) => {
-                self.emit(Instr::NotEquals(type_.index().unwrap()));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::NotEquals, _) => {
+                self.emit(Instr::NotEquals(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayClear, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayClear(type_));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::ArrayClear, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayClear(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::ArraySize, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArraySize(type_));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::ArraySize, TypeId::Array(_)) => {
+                self.emit(Instr::ArraySize(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::ArrayResize, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayResize(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayResize, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayResize(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayFindFirst, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayFindFirst(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayFindFirst, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayFindFirst(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayFindLast, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayFindLast(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayFindLast, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayFindLast(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayContains, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayContains(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayContains, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayContains(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayCount, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayCount(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayCount, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayCount(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayPush, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayPush(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayPush, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayPush(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayPop, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayPop(type_));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::ArrayPop, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayPop(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::ArrayInsert, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayInsert(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)?;
-                self.compile(&args[2], pool, scope)
+            (IntrinsicOp::ArrayInsert, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayInsert(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)?;
+                self.compile(&args[2], None, pool, scope)
             }
-            (IntrinsicOp::ArrayRemove, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayRemove(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayRemove, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayRemove(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayGrow, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayGrow(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayGrow, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayGrow(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayErase, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayErase(type_));
-                self.compile(&args[0], pool, scope)?;
-                self.compile(&args[1], pool, scope)
+            (IntrinsicOp::ArrayErase, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayErase(type_idx));
+                self.compile(&args[0], None, pool, scope)?;
+                self.compile(&args[1], None, pool, scope)
             }
-            (IntrinsicOp::ArrayLast, TypeId::Array(type_, _)) => {
-                self.emit(Instr::ArrayLast(type_));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::ArrayLast, TypeId::Array(_)) => {
+                self.emit(Instr::ArrayLast(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::ToString, any) => {
-                self.emit(Instr::ToString(any.index().unwrap()));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::ToString, _) => {
+                self.emit(Instr::ToString(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::EnumInt, any) => {
-                self.emit(Instr::EnumToI32(any.index().unwrap(), 4));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::EnumInt, _) => {
+                self.emit(Instr::EnumToI32(type_idx, 4));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::IntEnum, any) => {
-                self.emit(Instr::I32ToEnum(any.index().unwrap(), 4));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::IntEnum, _) => {
+                self.emit(Instr::I32ToEnum(type_idx, 4));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::ToVariant, any) => {
-                self.emit(Instr::ToVariant(any.index().unwrap()));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::ToVariant, _) => {
+                self.emit(Instr::ToVariant(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::FromVariant, any) => {
-                self.emit(Instr::ToVariant(any.index().unwrap()));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::FromVariant, _) => {
+                self.emit(Instr::ToVariant(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::AsRef, any) => {
-                self.emit(Instr::AsRef(any.index().unwrap()));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::AsRef, TypeId::ScriptRef(_)) => {
+                self.emit(Instr::AsRef(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            (IntrinsicOp::Deref, any) => {
-                self.emit(Instr::Deref(any.index().unwrap()));
-                self.compile(&args[0], pool, scope)
+            (IntrinsicOp::Deref, _) => {
+                self.emit(Instr::Deref(type_idx));
+                self.compile(&args[0], None, pool, scope)
             }
-            _ => {
-                let err = format!("Invalid intrinsic {} call", intrinsic);
+            (_, type_) => {
+                let err = format!("Invalid intrinsic {} call: {:?}", intrinsic, type_);
                 Err(Error::CompileError(err))
             }
         }
@@ -503,16 +525,21 @@ impl Assembler {
         code
     }
 
-    fn from_expr(expr: &Expr, pool: &mut ConstantPool, scope: &mut Scope) -> Result<Assembler, Error> {
+    fn from_expr(
+        expr: &Expr,
+        expected: Option<&TypeId>,
+        pool: &mut ConstantPool,
+        scope: &mut Scope,
+    ) -> Result<Assembler, Error> {
         let mut code = Assembler::new();
-        code.compile(expr, pool, scope)?;
+        code.compile(expr, expected, pool, scope)?;
         Ok(code)
     }
 
     pub fn from_seq(seq: &Seq, pool: &mut ConstantPool, scope: &mut Scope) -> Result<Assembler, Error> {
         let mut code = Assembler::new();
         for expr in &seq.exprs {
-            code.compile(expr, pool, scope)?;
+            code.compile(expr, None, pool, scope)?;
         }
         Ok(code)
     }

--- a/core/src/ast.rs
+++ b/core/src/ast.rs
@@ -147,12 +147,32 @@ pub struct TypeName {
     pub arguments: Vec<TypeName>,
 }
 
+impl Display for TypeName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.mangled())
+    }
+}
+
 impl TypeName {
     fn unwrapped(&self) -> &TypeName {
         match self.name.as_str() {
             "ref" => &self.arguments[0].unwrapped(),
             "wref" => &self.arguments[0].unwrapped(),
             _ => self,
+        }
+    }
+
+    pub fn basic(name: String) -> TypeName {
+        TypeName {
+            name,
+            arguments: vec![],
+        }
+    }
+
+    pub fn generic(name: String, arg: TypeName) -> TypeName {
+        TypeName {
+            name,
+            arguments: vec![arg],
         }
     }
 

--- a/resources/patches.reds
+++ b/resources/patches.reds
@@ -47,14 +47,14 @@ private func PopulateMenuItemList() {
 private final func GetSellableJunk() -> array<wref<gameItemData>> {
   let result: array<wref<gameItemData>>;
   let sellableItems = this.m_VendorDataManager.GetItemsPlayerCanSell();
-  let i = 0;
-  while i < ArraySize(sellableItems) {
+  let i: Uint32 = Cast(0);
+  while i < Cast(ArraySize(sellableItems)) {
     let type = RPGManager.GetItemRecord(sellableItems[i].GetID()).ItemType().Type();
-    if(Equals(type, gamedataItemType.Gen_Junk) || Equals(type, gamedataItemType.Con_Edible)) {
+    if Equals(type, gamedataItemType.Gen_Junk) || Equals(type, gamedataItemType.Con_Edible) {
         let tmp: wref<gameItemData> = sellableItems[i];
         ArrayPush(result, tmp);
     };
-    i += 1;
+    i += Cast(1);
   };
   return result;
 }


### PR DESCRIPTION
- Infer type from context allowing some kinds of code that was previously impossible like:
`let x: Int32 = Cast(0.0);`
or
`let newData: VehEntityPlayerStateData = FromVariant(data);`
- Add new type definitions to the constant pool, compiler previously depended on all types already being defined in the pool
- Improve overload resolution errors, for example:
```
Arguments passed to inkCompoundRef::GetWidgetByIndex do not match any of the overloads:
Parameter self: inkCompoundRef does not match provided SingleplayerMenuGameController
```