### PR TITLE
Added escape character support to String Literals

### DIFF
--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -177,7 +177,7 @@ peg::parser! {
                 String::from(char::from_u32(u32::from_str_radix(u, 16).unwrap()).unwrap())
             }
         
-        rule escaped_string() -> String
+        pub rule escaped_string() -> String
             = "\"" s:escaped_char()* "\"" { s.join("") }
 
         rule constant() -> Constant
@@ -466,14 +466,13 @@ mod tests {
 
     #[test]
     fn parse_escaped_string() {
-        let expr = lang::expr(
+        let escaped = lang::escaped_string(
             r#""This is a backslash \'\\\' \"escaped\" string \u{03BB}""#
         ).unwrap();
 
         assert_eq!(
-            // Debug formatting will escape the slashes and quotes again, but leave the lambda
-            format!("{:?}", expr),
-            r#"Constant(String(String, "This is a backslash \'\\\' \"escaped\" string λ"), Pos(0))"#
+            escaped,
+            r#"This is a backslash '\' "escaped" string λ"#
         );
     }
 }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -170,11 +170,21 @@ peg::parser! {
               else { Constant::Int(n.parse().unwrap()) }
             }
 
+        rule escaped_char() -> String
+            = !['\\' | '\"'] c:$([_]) { String::from(c) }
+            / "\\" c:$(['t' | 'r' | 'n' | '\'' | '"' | '\\']) { String::from(c) }
+            / "\\u{" u:$(['a'..='f' | 'A'..='F' | '0'..='9']*<1,6>) "}" {
+                String::from(char::from_u32(u32::from_str_radix(u, 16).unwrap()).unwrap())
+            }
+        
+        rule escaped_string() -> String
+            = "\"" s:escaped_char()* "\"" { s.join("") }
+
         rule constant() -> Constant
             = keyword("true") { Constant::Bool(true) }
             / keyword("false") { Constant::Bool(false) }
             / n:number() { n }
-            / type_:literal_type()? "\"" str:$((!['"'] [_])*) "\""
+            / type_:literal_type()? str:escaped_string()
                 { Constant::String(type_.unwrap_or(Literal::String), Rc::new(str.to_owned())) }
 
         rule seq() -> Seq<SourceAst> = exprs:(stmt() ** _) { Seq::new(exprs) }
@@ -451,6 +461,19 @@ mod tests {
         assert_eq!(
             format!("{:?}", stmt),
             r#"[Class(ClassSource { qualifiers: Qualifiers([]), name: "Test", base: None, members: [Field(FieldSource { declaration: Declaration { annotations: [], qualifiers: Qualifiers([Private]), name: "m_field", pos: Pos(114) }, type_: TypeName { name: Owned("String"), arguments: [] } })], pos: Pos(13) })]"#
+        );
+    }
+
+    #[test]
+    fn parse_escaped_string() {
+        let expr = lang::expr(
+            r#""This is a backslash \'\\\' \"escaped\" string \u{03BB}""#
+        ).unwrap();
+
+        assert_eq!(
+            // Debug formatting will escape the slashes and quotes again, but leave the lambda
+            format!("{:?}", expr),
+            r#"Constant(String(String, "This is a backslash \'\\\' \"escaped\" string λ"), Pos(0))"#
         );
     }
 }

--- a/decompiler/src/print.rs
+++ b/decompiler/src/print.rs
@@ -1,6 +1,5 @@
 use std::io::Write;
 use std::rc::Rc;
-use std::str;
 
 use redscript::ast::{BinOp, Constant, Expr, Ident, Literal, Seq, SourceAst, SwitchCase, UnOp};
 use redscript::bundle::ConstantPool;

--- a/decompiler/src/print.rs
+++ b/decompiler/src/print.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 use std::rc::Rc;
+use std::str;
 
 use redscript::ast::{BinOp, Constant, Expr, Ident, Literal, Seq, SourceAst, SwitchCase, UnOp};
 use redscript::bundle::ConstantPool;
@@ -226,10 +227,10 @@ fn write_expr<W: Write>(out: &mut W, expr: &Expr<SourceAst>, verbose: bool, dept
     match expr {
         Expr::Ident(ident, _) => write!(out, "{}", ident)?,
         Expr::Constant(cons, _) => match cons {
-            Constant::String(Literal::String, str) => write!(out, "\"{}\"", str)?,
-            Constant::String(Literal::Name, str) => write!(out, "n\"{}\"", str)?,
-            Constant::String(Literal::Resource, str) => write!(out, "r\"{}\"", str)?,
-            Constant::String(Literal::TweakDbId, str) => write!(out, "t\"{}\"", str)?,
+            Constant::String(Literal::String, str) => write!(out, "\"{}\"", str::escape_default(str))?,
+            Constant::String(Literal::Name, str) => write!(out, "n\"{}\"", str::escape_default(str))?,
+            Constant::String(Literal::Resource, str) => write!(out, "r\"{}\"", str::escape_default(str))?,
+            Constant::String(Literal::TweakDbId, str) => write!(out, "t\"{}\"", str::escape_default(str))?,
             Constant::Int(lit) => write!(out, "{}", lit)?,
             Constant::Uint(lit) => write!(out, "{}", lit)?,
             Constant::Float(lit) => write!(out, "{:.2}", lit)?,


### PR DESCRIPTION
Initially just added string escaping to the decompiler, as CP77 scripts have several log messages with a stylish `/!\` in them, breaking the formatting of the rest of the file. Added support on the compiler side too, although I haven't had a chance to thoroughly test it.

Supports character escapes for Swift as [documented here](https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html)
_(I know Redscript is not actually Swift, but might as well maintain compatibility)_
Rust's `str::escape_default(...)` uses the same escape formatting, so the decompiler code is a lot simpler.

I'm relatively new to Rust so let me know if I've made any horrible mistakes