### PR TITLE
Add Abstract and Final attribute support to classes

### DIFF
--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -270,7 +270,9 @@ impl<'a> Compiler<'a> {
         source: ClassSource,
         scope: &mut Scope,
     ) -> Result<(), Error> {
-        let flags = ClassFlags::new();
+        let flags = ClassFlags::new()
+            .with_is_abstract(decl.qualifiers.contain(Qualifier::Abstract));
+            .with_is_final(decl.qualifiers.contain(Qualifier::Final));
         let mut functions = vec![];
         let mut fields = vec![];
 

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -271,8 +271,8 @@ impl<'a> Compiler<'a> {
         scope: &mut Scope,
     ) -> Result<(), Error> {
         let flags = ClassFlags::new()
-            .with_is_abstract(decl.qualifiers.contain(Qualifier::Abstract));
-            .with_is_final(decl.qualifiers.contain(Qualifier::Final));
+            .with_is_abstract(source.qualifiers.contain(Qualifier::Abstract))
+            .with_is_final(source.qualifiers.contain(Qualifier::Final));
         let mut functions = vec![];
         let mut fields = vec![];
 

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -78,6 +78,7 @@ pub enum Qualifier {
     Public,
     Protected,
     Private,
+    Abstract,
     Static,
     Final,
     Const,
@@ -160,6 +161,7 @@ peg::parser! {
             = keyword("public") { Qualifier::Public }
             / keyword("protected") { Qualifier::Protected }
             / keyword("private") { Qualifier::Private }
+            / keyword("abstract") { Qualifier::Abstract }
             / keyword("static") { Qualifier::Static }
             / keyword("final") { Qualifier::Final }
             / keyword("const") { Qualifier::Const }

--- a/compiler/src/typechecker.rs
+++ b/compiler/src/typechecker.rs
@@ -168,12 +168,14 @@ impl<'a> TypeChecker<'a> {
             Expr::New(type_name, args, pos) => {
                 let type_ = scope.resolve_type(type_name, self.pool, *pos)?;
                 match type_ {
-                    TypeId::Class(_) => {
-                        if args.is_empty() {
-                            Expr::New(type_, vec![], *pos)
-                        } else {
+                    TypeId::Class(class_idx) => {
+                        if self.pool.class(class_idx)?.flags.is_abstract() {
+                            return Err(Error::class_is_abstract(type_name.mangled(), *pos));
+                        }
+                        if !args.is_empty() {
                             return Err(Error::invalid_arg_count(type_name.mangled(), 0, *pos));
                         }
+                        Expr::New(type_, vec![], *pos)
                     }
                     TypeId::Struct(class_idx) => {
                         let fields = self.pool.class(class_idx)?.fields.clone();

--- a/core/src/bundle.rs
+++ b/core/src/bundle.rs
@@ -386,6 +386,13 @@ impl<K> Names<K> {
             .cloned()
     }
 
+    pub fn get_index(&self, name: &String) -> Result<PoolIndex<K>, Error> {
+        self.mappings
+            .get(name)
+            .ok_or_else(|| Error::PoolError(format!("Name {} not found", name)))
+            .cloned()
+    }
+
     pub fn add(&mut self, str: Rc<String>) -> PoolIndex<K> {
         let idx = PoolIndex::new(self.strings.len());
         match self.mappings.entry(str.clone()) {

--- a/core/src/definition.rs
+++ b/core/src/definition.rs
@@ -644,7 +644,7 @@ impl Encode for ParameterFlags {
 }
 
 #[bitfield(bits = 16)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClassFlags {
     pub is_native: bool,
     pub is_abstract: bool,

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -33,6 +33,11 @@ impl Error {
         Error::CompileError(error, pos)
     }
 
+    pub fn class_is_abstract<N: Display>(class_name: N, pos: Pos) -> Error {
+        let error = format!("Cannot instantiate abstract class {}", class_name);
+        Error::CompileError(error, pos)
+    }
+
     pub fn unresolved_reference<N: Display>(name: N, pos: Pos) -> Error {
         let error = format!("Unresolved reference {}", name);
         Error::CompileError(error, pos)


### PR DESCRIPTION
RED4Engine support for `abstract` and `final` class attributes is weird. It happily accepts bytecode that instantiates abstract classes but won't execute their methods, and will also accept classes that extend final classes and will execute their methods.

For example, the following code happily compiles and runs:
```swift
public abstract class BaseClass {
  public func Foo() -> Void { Log("Base!"); }
}

public final class DerivedClass extends BaseClass {
  public func Foo() -> Void { Log("Derived!");  }
}

public class BeyondFinalClass extends DerivedClass {
  public func Foo() -> Void { Log("BeyondFinal!");  }
}

public static exec func TestInheritance(gi: GameInstance) {
  let b: ref<BaseClass> = new BaseClass();
  let f: ref<BaseClass> = new BeyondFinalClass();

  b.Foo();
  f.Foo();
}
```

However when called from the CET Console, the base class instance is ignored entirely and the beyond final class is executed:
![testinheritance](https://user-images.githubusercontent.com/6767042/117090710-a548c080-ad8b-11eb-916a-bec47da2bcc6.png)

I suspect CDPR's scripting language enforces these attributes at the compiler level. I've added a compilation error for instantiating an abstract class, but I'm a bit lost with the remaining typechecker.rs logic to add error checks on extending a final class.

I also made some minor changes to support testing the compiled class flags and cleaned up some of the duplicated testing code