### PR TITLE
Fixed bug with encoding new native functions

### DIFF
--- a/core/src/definition.rs
+++ b/core/src/definition.rs
@@ -354,8 +354,10 @@ impl Encode for Function {
 
         output.encode(&value.visibility)?;
         output.encode(&flags)?;
-        if let Some(ref source) = value.source {
-            output.encode(source)?;
+        if !flags.is_native() {
+            if let Some(ref source) = value.source {
+                output.encode(source)?;
+            }
         }
         if let Some(ref type_) = value.return_type {
             output.encode(type_)?;


### PR DESCRIPTION
Function decode method was correctly skipping reading any SourceFile data for native flagged functions, but the encode method would write it if the SourceFile was defined, making it impossible to create new native methods.