### PR TITLE
UTF8 String Decoding

### DIFF
--- a/compiler/tests/tests.rs
+++ b/compiler/tests/tests.rs
@@ -554,6 +554,31 @@ fn compile_number_literals() -> Result<(), Error> {
 }
 
 #[test]
+fn compile_string_literals() -> Result<(), Error> {
+    let sources = r#"
+        func Testing() {
+            let a: String = "\u{1F4A9}";
+            let b: CName = n"back";
+            //let c: ResRef = r"base\\gameplay\\gui\\common\\buttonhints.inkwidget";
+            let d: TweakDBID = t"MappinIcons.QuestMappin";
+        }
+        "#;
+    let expected = vec![
+        Instr::Assign,
+        Instr::Local(PoolIndex::new(22)),
+        Instr::StringConst(PoolIndex::new(0)),
+        Instr::Assign,
+        Instr::Local(PoolIndex::new(23)),
+        Instr::NameConst(PoolIndex::new(25)),
+        Instr::Assign,
+        Instr::Local(PoolIndex::new(24)),
+        Instr::TweakDbIdConst(PoolIndex::new(0)),
+        Instr::Nop,
+    ];
+    check_function_bytecode(sources, expected)
+}
+
+#[test]
 fn compile_is_defined() -> Result<(), Error> {
     let sources = "
         func Testing() {

--- a/core/src/decode.rs
+++ b/core/src/decode.rs
@@ -85,16 +85,15 @@ impl Decode for f32 {
 
 impl Decode for String {
     fn decode<I: io::Read>(input: &mut I) -> io::Result<Self> {
-        let mut str = String::new();
-        let mut c: u8;
+        let mut buf = Vec::new();
         loop {
-            c = input.read_u8()?;
+            let c = input.read_u8()?;
             if c == 0 {
                 break;
             }
-            str.push(c.into());
+            buf.push(c);
         }
-        Ok(str)
+        String::from_utf8(buf).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
     }
 }
 


### PR DESCRIPTION
Updated the string decode method to support multibyte characters.

Added a test case for string literals too, but had to comment out the `ResRef` test as it's not defined in `predef.redscripts`