### PR TITLE
Allow multiple -compile args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "bpaf"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "423bafba382cc2c561f486bfcae41c6692833eaff0a631d10c37a9489ccd3783"
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1153,7 @@ dependencies = [
 name = "scc"
 version = "0.5.11"
 dependencies = [
+ "bpaf",
  "byteorder",
  "fd-lock",
  "flexi_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ dependencies = [
  "serde",
  "toml",
  "vmap",
+ "winsplit",
 ]
 
 [[package]]
@@ -1529,3 +1530,9 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winsplit"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab703352da6a72f35c39a533526393725640575bb211f61987a2748323ad956"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -106,7 +106,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 fn compile(opts: CompileOpts) -> Result<(), redscript_compiler::error::Error> {
     let mut bundle = load_bundle(&opts.bundle)?;
 
-    let files = Files::from_dir(&opts.src, SourceFilter::None)?;
+    let files = Files::from_dir(&opts.src, &SourceFilter::None)?;
 
     match CompilationUnit::new_with_defaults(&mut bundle.pool)?.compile_and_report(&files) {
         Ok(()) => {
@@ -164,7 +164,7 @@ fn lint(opts: LintOpts) -> Result<(), redscript_compiler::error::Error> {
         Some(bundle_path) => {
             let mut bundle = load_bundle(&bundle_path)?;
 
-            let files = Files::from_dir(&opts.src, SourceFilter::None)?;
+            let files = Files::from_dir(&opts.src, &SourceFilter::None)?;
 
             if CompilationUnit::new_with_defaults(&mut bundle.pool)?
                 .compile_and_report(&files)

--- a/compiler/src/source_map.rs
+++ b/compiler/src/source_map.rs
@@ -23,8 +23,8 @@ impl Files {
         let mut files = Self::new();
         for path in paths {
             if path.is_file() {
-                let sources = std::fs::read_to_string(&path)?;
-                files.add(path.to_path_buf(), sources);
+                let sources = std::fs::read_to_string(path)?;
+                files.add(path.clone(), sources);
             } else {
                 let iter = WalkDir::new(path)
                 .into_iter()
@@ -33,7 +33,7 @@ impl Files {
                 .filter(|p| filter.apply(p.strip_prefix(path).unwrap()));
                 for file_path in iter {
                     let sources = std::fs::read_to_string(&file_path)?;
-                    files.add(file_path.to_path_buf(), sources);
+                    files.add(file_path.clone(), sources);
                 }
             }
         }

--- a/compiler/src/source_map.rs
+++ b/compiler/src/source_map.rs
@@ -19,7 +19,7 @@ impl Files {
         Self::default()
     }
 
-    pub fn from_dirs(paths: &Vec<PathBuf>, filter: SourceFilter) -> Result<Self, Error> {
+    pub fn from_dirs(paths: &[PathBuf], filter: SourceFilter) -> Result<Self, Error> {
         let mut files = Self::new();
         for path in paths {
             if path.is_file() {

--- a/scc/Cargo.toml
+++ b/scc/Cargo.toml
@@ -15,7 +15,7 @@ toml = "0.5"
 vmap = { version = "0.5", default-features = false, optional = true }
 fd-lock = "3"
 msgbox = { version = "0.7", optional = true }
-bpaf = "0.7.10"
+bpaf = "0.7"
 winsplit = "0.1"
 
 [features]

--- a/scc/Cargo.toml
+++ b/scc/Cargo.toml
@@ -16,6 +16,7 @@ vmap = { version = "0.5", default-features = false, optional = true }
 fd-lock = "3"
 msgbox = { version = "0.7", optional = true }
 bpaf = "0.7.10"
+winsplit = "0.1"
 
 [features]
 popup = ["msgbox"]

--- a/scc/Cargo.toml
+++ b/scc/Cargo.toml
@@ -15,6 +15,7 @@ toml = "0.5"
 vmap = { version = "0.5", default-features = false, optional = true }
 fd-lock = "3"
 msgbox = { version = "0.7", optional = true }
+bpaf = "0.7.10"
 
 [features]
 popup = ["msgbox"]

--- a/scc/src/lib.rs
+++ b/scc/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod opts;

--- a/scc/src/main.rs
+++ b/scc/src/main.rs
@@ -9,6 +9,7 @@ use std::time::SystemTime;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use fd_lock::RwLock;
 use flexi_logger::{Age, Cleanup, Criterion, Duplicate, FileSpec, LevelFilter, LogSpecBuilder, Logger, Naming};
+use opts::Opts;
 use redscript::ast::Span;
 use redscript::bundle::ScriptBundle;
 use redscript_compiler::error::Error;
@@ -19,6 +20,7 @@ use serde::Deserialize;
 use crate::hints::UserHints;
 
 mod hints;
+mod opts;
 
 const BUNDLE_FILE_NAME: &str = "final.redscripts";
 const BACKUP_FILE_NAME: &str = "final.redscripts.bk";
@@ -27,54 +29,51 @@ const TIMESTAMP_FILE_NAME: &str = "redscript.ts";
 const USER_HINTS_DIR: &str = "redsUserHints";
 
 fn main() -> ExitCode {
-    let mut arg_iter = std::env::args().skip(1);
-    if let (Some("-compile"), Some(path_str)) = (arg_iter.next().as_deref(), arg_iter.next()) {
-        // the way cyberpunk passes CLI args is broken, this is a workaround
-        let script_dir = PathBuf::from(path_str.split('"').next().unwrap());
-        let r6_dir = script_dir.parent().unwrap();
-        let default_cache_dir = r6_dir.join("cache");
 
-        setup_logger(r6_dir);
+    let opts = Opts::load(std::env::args().skip(1).collect::<Vec<String>>());
 
-        let manifest = ScriptManifest::load(&script_dir).unwrap_or_else(|err| {
-            log::info!("Using defaults for the script manifest ({err})");
-            ScriptManifest::default()
-        });
+    log::debug!("{:#?}", opts);
 
-        let (cache_dir, fallback_dir) = match (arg_iter.next().as_deref(), arg_iter.next()) {
-            (Some("-customCacheDir"), Some(custom_path)) => {
-                log::info!("Custom cache directory provided: {}", custom_path);
-                let cache_dir = PathBuf::from(custom_path);
-                let expected_bundle_path = cache_dir.join(BUNDLE_FILE_NAME);
-                if !expected_bundle_path.exists() {
-                    let base = get_base_bundle_path(&default_cache_dir);
-                    fs::create_dir_all(&cache_dir).expect("Could not create the custom cache directory");
-                    fs::copy(base, expected_bundle_path).expect("Could not copy base bundle");
-                }
-                (cache_dir, Some(default_cache_dir))
+    let script_dir = PathBuf::from(opts.script_paths.first().unwrap());
+    let r6_dir = script_dir.parent().unwrap();
+    let default_cache_dir = r6_dir.join("cache");
+
+    setup_logger(r6_dir);
+
+    let manifest = ScriptManifest::load(&script_dir).unwrap_or_else(|err| {
+        log::info!("Using defaults for the script manifest ({err})");
+        ScriptManifest::default()
+    });
+
+    let (cache_dir, fallback_dir) = match opts.cache_dir {
+        Some(cache_dir) => {
+            log::info!("Custom cache directory provided: {}", cache_dir.to_str().unwrap());
+            let expected_bundle_path = cache_dir.join(BUNDLE_FILE_NAME);
+            if !expected_bundle_path.exists() {
+                let base = get_base_bundle_path(&default_cache_dir);
+                fs::create_dir_all(&cache_dir).expect("Could not create the custom cache directory");
+                fs::copy(base, expected_bundle_path).expect("Could not copy base bundle");
             }
-            _ => (default_cache_dir, None),
-        };
-
-        let files = Files::from_dir(&script_dir, manifest.source_filter()).expect("Could not load script sources");
-
-        match compile_scripts(&script_dir, &cache_dir, fallback_dir.as_deref(), &files) {
-            Ok(_) => {
-                log::info!("Output successfully saved in {}", cache_dir.display());
-                ExitCode::SUCCESS
-            }
-            Err(err) => {
-                let content = error_message(err, &files, r6_dir);
-                #[cfg(feature = "popup")]
-                msgbox::create("Compilation error", &content, msgbox::IconType::Error).unwrap();
-
-                log::error!("Compilation error: {}", content);
-                ExitCode::FAILURE
-            }
+            (cache_dir, Some(default_cache_dir))
         }
-    } else {
-        log::error!("Invalid command-line arguments");
-        ExitCode::FAILURE
+        _ => (default_cache_dir, None),
+    };
+
+    let files = Files::from_dirs(&opts.script_paths, manifest.source_filter()).expect("Could not load script sources");
+
+    match compile_scripts(&script_dir, &cache_dir, fallback_dir.as_deref(), &files) {
+        Ok(_) => {
+            log::info!("Output successfully saved in {}", cache_dir.display());
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            let content = error_message(err, &files, r6_dir);
+            #[cfg(feature = "popup")]
+            msgbox::create("Compilation error", &content, msgbox::IconType::Error).unwrap();
+
+            log::error!("Compilation error: {}", content);
+            ExitCode::FAILURE
+        }
     }
 }
 

--- a/scc/src/main.rs
+++ b/scc/src/main.rs
@@ -9,12 +9,12 @@ use std::time::SystemTime;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use fd_lock::RwLock;
 use flexi_logger::{Age, Cleanup, Criterion, Duplicate, FileSpec, LevelFilter, LogSpecBuilder, Logger, Naming};
-use opts::Opts;
 use redscript::ast::Span;
 use redscript::bundle::ScriptBundle;
 use redscript_compiler::error::Error;
 use redscript_compiler::source_map::{Files, SourceFilter};
 use redscript_compiler::unit::CompilationUnit;
+use opts::{fix_args, Opts};
 use serde::Deserialize;
 
 use crate::hints::UserHints;
@@ -30,9 +30,10 @@ const USER_HINTS_DIR: &str = "redsUserHints";
 
 fn main() -> ExitCode {
 
-    let opts = Opts::load(std::env::args().skip(1).collect::<Vec<String>>());
+    let opts = Opts::load(fix_args(std::env::args().skip(1).collect::<Vec<String>>()));
 
-    log::debug!("{:#?}", opts);
+    #[cfg(test)]
+    log::info!("{:#?}", opts);
 
     let script_dir = PathBuf::from(opts.script_paths.first().unwrap());
     let r6_dir = script_dir.parent().unwrap();

--- a/scc/src/main.rs
+++ b/scc/src/main.rs
@@ -9,12 +9,12 @@ use std::time::SystemTime;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use fd_lock::RwLock;
 use flexi_logger::{Age, Cleanup, Criterion, Duplicate, FileSpec, LevelFilter, LogSpecBuilder, Logger, Naming};
+use opts::{fix_args, Opts};
 use redscript::ast::Span;
 use redscript::bundle::ScriptBundle;
 use redscript_compiler::error::Error;
 use redscript_compiler::source_map::{Files, SourceFilter};
 use redscript_compiler::unit::CompilationUnit;
-use opts::{fix_args, Opts};
 use serde::Deserialize;
 
 use crate::hints::UserHints;
@@ -29,7 +29,6 @@ const TIMESTAMP_FILE_NAME: &str = "redscript.ts";
 const USER_HINTS_DIR: &str = "redsUserHints";
 
 fn main() -> ExitCode {
-
     let opts = Opts::load(fix_args(std::env::args().skip(1).collect::<Vec<String>>()));
 
     #[cfg(test)]
@@ -60,7 +59,7 @@ fn main() -> ExitCode {
         _ => (default_cache_dir, None),
     };
 
-    let files = Files::from_dirs(&opts.script_paths, manifest.source_filter()).expect("Could not load script sources");
+    let files = Files::from_dirs(&opts.script_paths, &manifest.source_filter()).expect("Could not load script sources");
 
     match compile_scripts(&script_dir, &cache_dir, fallback_dir.as_deref(), &files) {
         Ok(_) => {

--- a/scc/src/main.rs
+++ b/scc/src/main.rs
@@ -29,7 +29,7 @@ const TIMESTAMP_FILE_NAME: &str = "redscript.ts";
 const USER_HINTS_DIR: &str = "redsUserHints";
 
 fn main() -> ExitCode {
-    let opts = Opts::load(fix_args(std::env::args().skip(1).collect::<Vec<String>>()));
+    let opts = Opts::load(fix_args(std::env::args().skip(1).collect()).iter().map(String::as_str).collect::<Vec<&str>>().as_slice());
 
     #[cfg(test)]
     log::info!("{:#?}", opts);

--- a/scc/src/opts.rs
+++ b/scc/src/opts.rs
@@ -1,0 +1,142 @@
+use bpaf::*;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::collections::VecDeque;
+
+pub fn fix_args(args: Vec<String>) -> Vec<String> {
+    let mut fixed_args: Vec<String> = vec![];
+    let mut broken = false;
+
+    log::debug!("{:#?}", args);
+
+    // when cyberpunk's args are processed, the \" messes up the grouping, so we need to fix the args that have quotes & spaces in them
+    for arg in args {
+        if !arg.contains("\"") && !broken {
+            fixed_args.push(arg.to_owned());
+        } else {
+            if !broken {
+                broken = true;
+                let spaceless = arg.replace("\"", "\\\"");
+                for part in spaceless.split("\"") {
+                    fixed_args.push(part.to_string());
+                }
+            } else {
+                // fixes args that come after the first
+                let broken_arg = if arg.contains("\"") {
+                    arg.replace("\"", "\\")
+                } else {
+                    arg
+                };
+                if broken_arg.contains(" ") {
+                    let mut parts = broken_arg.split(' ').collect::<VecDeque<&str>>();
+                    let last = fixed_args.last().unwrap();
+                    *fixed_args.last_mut().unwrap() = format!("{} {}", last, &parts.pop_front().unwrap());
+                    for part in parts {
+                        fixed_args.push(part.to_string());
+                    }
+                } else {
+                    let last = fixed_args.last().unwrap();
+                    *fixed_args.last_mut().unwrap() = format!("{} {}", last, broken_arg);
+                }
+            }
+        }
+    }
+
+    log::debug!("{:#?}", fixed_args);
+
+    fixed_args
+}
+
+#[derive(Clone, Debug)]
+pub struct Opts {
+    pub script_paths: Vec<PathBuf>,
+    pub cache_file: PathBuf,
+    pub cache_dir: Option<PathBuf>,
+    pub optimize: bool,
+    pub threads: Option<u8>,
+    pub no_warnings: bool,
+    pub no_testonly: bool,
+    pub no_breakpoint: bool,
+    pub profile_off: bool
+}
+
+fn toggle_options(name: &'static str, help: &'static str) -> impl Parser<bool> {
+    any::<String>(name)
+        .help(help)
+        .guard(|s| s.starts_with("-"), "doesn't start with -")
+        .parse(move |s| {
+            let (state, cur_name) = if let Some(rest) = s.strip_prefix('-') {
+                (true, rest)
+            } else {
+                return Err(format!("{} is not a toggle option", s));
+            };
+            if cur_name != name {
+                Err(format!("{} is not a known toggle option name", cur_name))
+            } else {
+                Ok(state)
+            }
+        })
+        .anywhere()
+}
+
+fn slong(tag_str: &'static str, arg_str: &'static str) -> impl Parser<String> {
+    let tag = any::<String>(tag_str)
+        .guard(|s| s.as_str() == tag_str.to_owned(), "not arg name");
+    let value = positional::<String>(arg_str);
+    construct!(tag, value)
+        .anywhere()
+        .map(|pair| pair.1)
+}
+
+fn script_paths() -> impl Parser<Vec<PathBuf>> {
+    let tag = any::<String>("-compile")
+        .guard(|s| s == "-compile", "not compile");
+    let value = positional::<OsString>("SCRIPT_PATH");
+    construct!(tag, value)
+        .anywhere()
+        .map(|pair| pair.1)
+        .map(PathBuf::from)
+        .many()
+        .catch()
+}
+
+fn cache_dir() -> impl Parser<Option<PathBuf>> {
+    let tag = any::<String>("-customCacheDir")
+        .guard(|s| s == "-customCacheDir", "not customCacheDir");
+    let value = positional::<OsString>("CACHE_DIR");
+    construct!(tag, value)
+        .anywhere()
+        .map(|pair| pair.1)
+        .map(PathBuf::from)
+        .optional()
+        .catch()
+}
+
+impl Opts {
+    pub fn load(args: Vec<String>) -> Self {
+        let cache_file = any::<OsString>("CACHE_FILE")
+            .anywhere()
+            .map(PathBuf::from);
+        let optimize = toggle_options("optimize", "Optimize the redscripts");
+        let threads = slong("-threads", "Number of theads to script_paths on").map(|s| s.parse::<u8>().unwrap()).optional();
+        let no_warnings = toggle_options("Wnone", "No warnings");
+        let no_testonly = toggle_options("no-testonly", "No testonly classes");
+        let no_breakpoint = toggle_options("no-breakpoint", "No breakpoints");
+        let profile_off = toggle_options("profile=off", "Profile off");
+
+        let parser = construct!(Opts {
+            script_paths(),
+            cache_file,
+            cache_dir(),
+            optimize,
+            threads,
+            no_warnings,
+            no_testonly,
+            no_breakpoint,
+            profile_off
+        });
+        let fixed_args = fix_args(args);
+        let bpaf_args = fixed_args.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
+        parser.to_options().run_inner(bpaf::Args::from(bpaf_args.as_slice())).unwrap()
+    }
+}

--- a/scc/src/opts.rs
+++ b/scc/src/opts.rs
@@ -19,13 +19,13 @@ pub fn fix_args(args: Vec<String>) -> Vec<String> {
             fixed_args.push(arg);
         } else if !broken {
             let slashful = arg.replace('"', "\\\"").replace("\" ", "\"");
-            let mut parts = slashful.split("\"").collect::<VecDeque<&str>>();
+            let mut parts = slashful.split('"').collect::<VecDeque<&str>>();
             fixed_args.push(parts.pop_front().unwrap().to_string());
             for part in parts {
                 if part.is_empty() {
                     continue;
                 }
-                for p in part.split(" ") {
+                for p in part.split(' ') {
                     fixed_args.push(p.to_string());
                 }
             }

--- a/scc/tests/args.rs
+++ b/scc/tests/args.rs
@@ -1,0 +1,190 @@
+use scc::opts::*;
+use std::path::PathBuf;
+use winsplit;
+use std::{println as info};
+
+pub fn test_fix_args(arg_str: &str, expected_args: &[&str]) -> Result<Vec<String>, String> {
+    let args = fix_args(winsplit::split(arg_str));
+    (args == expected_args.iter().map(|&s| s.into()).collect::<Vec<String>>()).then_some(args).ok_or("Does not match expected output".to_owned())
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_standard() {
+        let args = test_fix_args(concat!(
+            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
+            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
+            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#),
+            &[
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
+                "-Wnone",
+                "-threads",
+                "4",
+                "-no-testonly",
+                "-no-breakpoint",
+                "-profile=off",
+                "-optimize"
+            ]
+        ).unwrap();
+        let opts = Opts::load(args);
+        info!("{:#?}", opts);
+
+        assert!(opts.script_paths == vec![PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\")]);
+        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
+        assert!(opts.cache_dir == None);
+        assert!(opts.threads == Some(4));
+    }
+
+    #[test]
+    fn test_custom_files() {
+        let args = test_fix_args(concat!(
+            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
+            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
+            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#,
+            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\my_mod.module.reds""#,
+            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\my_mod.packed.reds""#),
+            &[
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
+                "-Wnone",
+                "-threads",
+                "4",
+                "-no-testonly",
+                "-no-breakpoint",
+                "-profile=off",
+                "-optimize",
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.module.reds",
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds"
+            ]
+        ).unwrap();
+        let opts = Opts::load(args);
+        info!("{:#?}", opts);
+
+        assert!(opts.script_paths == vec![
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\"),
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.module.reds"),
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds")
+        ]);
+        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
+        assert!(opts.cache_dir == None);
+        assert!(opts.threads == Some(4));
+    }
+
+    #[test]
+    fn test_custom_folder() {
+        let args = test_fix_args(concat!(
+            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
+            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
+            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#,
+            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\""#),
+            &[
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
+                "-Wnone",
+                "-threads",
+                "4",
+                "-no-testonly",
+                "-no-breakpoint",
+                "-profile=off",
+                "-optimize",
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\"
+            ]
+        ).unwrap();
+        let opts = Opts::load(args);
+        info!("{:#?}", opts);
+
+        assert!(opts.script_paths == vec![
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\"),
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\")
+        ]);
+        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
+        assert!(opts.cache_dir == None);
+        assert!(opts.threads == Some(4));
+    }
+
+    #[test]
+    fn test_custom_folder_file() {
+        let args = test_fix_args(concat!(
+            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
+            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
+            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#,
+            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\""#,
+            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\my_mod.packed.reds""#),
+            &[
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
+                "-Wnone",
+                "-threads",
+                "4",
+                "-no-testonly",
+                "-no-breakpoint",
+                "-profile=off",
+                "-optimize",
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\",
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds"
+            ]
+        ).unwrap();
+        let opts = Opts::load(args);
+        info!("{:#?}", opts);
+
+        assert!(opts.script_paths == vec![
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\"),
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\"),
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds")
+        ]);
+        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
+        assert!(opts.cache_dir == None);
+        assert!(opts.threads == Some(4));
+    }
+
+    #[test]
+    fn test_custom_file_folder() {
+        let args = test_fix_args(concat!(
+            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
+            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
+            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#,
+            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\my_mod.packed.reds""#,
+            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\extra\""#,
+        ),
+            &[
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
+                "-Wnone",
+                "-threads",
+                "4",
+                "-no-testonly",
+                "-no-breakpoint",
+                "-profile=off",
+                "-optimize",
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds",
+                "-compile",
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\extra\\",
+            ]
+        ).unwrap();
+        let opts = Opts::load(args);
+        info!("{:#?}", opts);
+
+        assert!(opts.script_paths == vec![
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\"),
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds"),
+            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\extra\\"),
+        ]);
+        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
+        assert!(opts.cache_dir == None);
+        assert!(opts.threads == Some(4));
+    }
+}

--- a/scc/tests/args.rs
+++ b/scc/tests/args.rs
@@ -1,190 +1,73 @@
 use scc::opts::*;
 use std::path::PathBuf;
 use winsplit;
-use std::{println as info};
+use std::println;
 
 pub fn test_fix_args(arg_str: &str, expected_args: &[&str]) -> Result<Vec<String>, String> {
     let args = fix_args(winsplit::split(arg_str));
     (args == expected_args.iter().map(|&s| s.into()).collect::<Vec<String>>()).then_some(args).ok_or("Does not match expected output".to_owned())
 }
 
+pub struct TestArg {
+    pub raw: &'static str,
+    pub parsed: &'static str,
+}
+
+const TEST_FILE: TestArg = TestArg {
+    raw: r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\packed.reds""#,
+    parsed: "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\packed.reds"
+};
+
+const TEST_DIRECTORY: TestArg = TestArg {
+    raw: r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\extra\""#,
+    parsed: "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\extra\\"
+};
+
+fn test_order(f_args: &[TestArg]) {
+    let args = test_fix_args(&[concat!(
+        r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\""#,
+        r#" "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
+        r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#), &f_args.iter().map(|a| a.raw).collect::<Vec<_>>().join("")].join(""),
+        &[&[
+            "-compile",
+            "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
+            "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
+            "-Wnone",
+            "-threads",
+            "4",
+            "-no-testonly",
+            "-no-breakpoint",
+            "-profile=off",
+            "-optimize",
+        ], f_args.iter().flat_map(|a| ["-compile", a.parsed]).collect::<Vec<_>>().as_slice()].concat()
+    ).unwrap();
+    let opts = Opts::load(args.iter().map(String::as_str).collect::<Vec<&str>>().as_slice());
+    println!("{:#?}", opts);
+
+    assert!(opts.script_paths == [vec![PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\")],
+        f_args.iter().map(|a| PathBuf::from(a.parsed)).collect()
+    ].concat());
+    assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
+    assert!(opts.cache_dir == None);
+    assert!(opts.threads == Some(4));
+}
+
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_standard() {
-        let args = test_fix_args(concat!(
-            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
-            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
-            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#),
-            &[
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
-                "-Wnone",
-                "-threads",
-                "4",
-                "-no-testonly",
-                "-no-breakpoint",
-                "-profile=off",
-                "-optimize"
-            ]
-        ).unwrap();
-        let opts = Opts::load(args);
-        info!("{:#?}", opts);
-
-        assert!(opts.script_paths == vec![PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\")]);
-        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
-        assert!(opts.cache_dir == None);
-        assert!(opts.threads == Some(4));
-    }
-
-    #[test]
-    fn test_custom_files() {
-        let args = test_fix_args(concat!(
-            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
-            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
-            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#,
-            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\my_mod.module.reds""#,
-            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\my_mod.packed.reds""#),
-            &[
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
-                "-Wnone",
-                "-threads",
-                "4",
-                "-no-testonly",
-                "-no-breakpoint",
-                "-profile=off",
-                "-optimize",
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.module.reds",
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds"
-            ]
-        ).unwrap();
-        let opts = Opts::load(args);
-        info!("{:#?}", opts);
-
-        assert!(opts.script_paths == vec![
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\"),
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.module.reds"),
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds")
-        ]);
-        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
-        assert!(opts.cache_dir == None);
-        assert!(opts.threads == Some(4));
-    }
-
-    #[test]
-    fn test_custom_folder() {
-        let args = test_fix_args(concat!(
-            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
-            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
-            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#,
-            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\""#),
-            &[
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
-                "-Wnone",
-                "-threads",
-                "4",
-                "-no-testonly",
-                "-no-breakpoint",
-                "-profile=off",
-                "-optimize",
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\"
-            ]
-        ).unwrap();
-        let opts = Opts::load(args);
-        info!("{:#?}", opts);
-
-        assert!(opts.script_paths == vec![
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\"),
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\")
-        ]);
-        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
-        assert!(opts.cache_dir == None);
-        assert!(opts.threads == Some(4));
-    }
-
-    #[test]
-    fn test_custom_folder_file() {
-        let args = test_fix_args(concat!(
-            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
-            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
-            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#,
-            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\""#,
-            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\my_mod.packed.reds""#),
-            &[
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
-                "-Wnone",
-                "-threads",
-                "4",
-                "-no-testonly",
-                "-no-breakpoint",
-                "-profile=off",
-                "-optimize",
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\",
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds"
-            ]
-        ).unwrap();
-        let opts = Opts::load(args);
-        info!("{:#?}", opts);
-
-        assert!(opts.script_paths == vec![
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\"),
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\"),
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds")
-        ]);
-        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
-        assert!(opts.cache_dir == None);
-        assert!(opts.threads == Some(4));
-    }
-
-    #[test]
-    fn test_custom_file_folder() {
-        let args = test_fix_args(concat!(
-            r#"-compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\scripts\" "#,
-            r#""C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\r6\cache\final.redscripts""#,
-            r#" -Wnone -threads 4 -no-testonly -no-breakpoint -profile=off -optimize"#,
-            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\my_mod.packed.reds""#,
-            r#" -compile "C:\Program Files (x86)\Steam\steamapps\common\Cyberpunk 2077\red4ext\plugins\my_mod\extra\""#,
-        ),
-            &[
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts",
-                "-Wnone",
-                "-threads",
-                "4",
-                "-no-testonly",
-                "-no-breakpoint",
-                "-profile=off",
-                "-optimize",
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds",
-                "-compile",
-                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\extra\\",
-            ]
-        ).unwrap();
-        let opts = Opts::load(args);
-        info!("{:#?}", opts);
-
-        assert!(opts.script_paths == vec![
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\scripts\\"),
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\my_mod.packed.reds"),
-            PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\red4ext\\plugins\\my_mod\\extra\\"),
-        ]);
-        assert!(opts.cache_file == PathBuf::from("C:\\Program Files (x86)\\Steam\\steamapps\\common\\Cyberpunk 2077\\r6\\cache\\final.redscripts"));
-        assert!(opts.cache_dir == None);
-        assert!(opts.threads == Some(4));
-    }
+    #[test] fn test_standard() { test_order(&[]); }
+    #[test] fn test_fd() { test_order(&[TEST_FILE, TEST_DIRECTORY]); }
+    #[test] fn test_fdf() { test_order(&[TEST_FILE, TEST_FILE, TEST_FILE]); }
+    #[test] fn test_ffd() { test_order(&[TEST_FILE, TEST_FILE, TEST_DIRECTORY]); }
+    #[test] fn test_fdd() { test_order(&[TEST_FILE, TEST_DIRECTORY, TEST_DIRECTORY]); }
+    #[test] fn test_fddf() { test_order(&[TEST_FILE, TEST_DIRECTORY, TEST_DIRECTORY, TEST_FILE]); }
+    #[test] fn test_fdfd() { test_order(&[TEST_FILE, TEST_DIRECTORY, TEST_DIRECTORY, TEST_FILE]); }
+    #[test] fn test_fddfd() { test_order(&[TEST_FILE, TEST_DIRECTORY, TEST_DIRECTORY, TEST_FILE, TEST_DIRECTORY]); }
+    #[test] fn test_df() { test_order(&[TEST_DIRECTORY, TEST_FILE]); }
+    #[test] fn test_dfd() { test_order(&[TEST_DIRECTORY, TEST_FILE, TEST_DIRECTORY]); }
+    #[test] fn test_ddf() { test_order(&[TEST_DIRECTORY, TEST_DIRECTORY, TEST_FILE]); }
+    #[test] fn test_dff() { test_order(&[TEST_DIRECTORY, TEST_FILE, TEST_FILE]); }
+    #[test] fn test_dffd() { test_order(&[TEST_DIRECTORY, TEST_FILE, TEST_FILE, TEST_DIRECTORY]); }
+    #[test] fn test_dfdf() { test_order(&[TEST_DIRECTORY, TEST_FILE, TEST_FILE, TEST_DIRECTORY]); }
+    #[test] fn test_dffdf() { test_order(&[TEST_DIRECTORY, TEST_FILE, TEST_FILE, TEST_DIRECTORY, TEST_FILE]); }
 }


### PR DESCRIPTION
* Fixes Cyberpunk's escaped arg string mess
* Uses bpaf for argument parsing
  * Existing Cyberpunk args are "supported" but do nothing
  * More will need to be added if command arg changes (possibly in different scenarios)
* Allows multiple `-compile <SOURCE_PATH>` args, supporting files or folders
* Adds tests for default commands & likely scenarios