### PR TITLE
Docs: Document `Instr` and public types in `io` crate

### DIFF
--- a/crates/io/src/definition.rs
+++ b/crates/io/src/definition.rs
@@ -14,6 +14,7 @@ use crate::util::{self, FlagDependent, OptionalIndex, Prefixed};
 use crate::{ENDIANESS, Offset, Str};
 
 #[derive(Debug, Default, Clone, Copy, TryRead, TryWrite, Measure)]
+/// Header information for a definition in the pool.
 pub struct DefinitionHeader {
     name: CNameIndex,
     parent: u32,
@@ -43,6 +44,7 @@ impl DefinitionHeader {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Represents a definition in the pool.
 pub enum Definition<'i> {
     Type(Type),
     Class(Box<Class>),
@@ -75,6 +77,7 @@ impl Definition<'_> {
         }
     }
 
+    /// name
     pub fn name(&self) -> CNameIndex {
         match self {
             Definition::Type(t) => t.name,
@@ -104,6 +107,7 @@ impl Definition<'_> {
         }
     }
 
+    /// into_owned
     pub fn into_owned(self) -> Definition<'static> {
         match self {
             Definition::Type(t) => Definition::Type(t),
@@ -251,6 +255,7 @@ impl<Ctx: Copy> Measure<Ctx> for Definition<'_> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// A definition with its corresponding index.
 pub enum IndexedDefinition<'b, 'i> {
     Type(TypeIndex, &'b Type),
     Class(ClassIndex, &'b Class),
@@ -265,6 +270,7 @@ pub enum IndexedDefinition<'b, 'i> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a type definition.
 pub struct Type {
     #[byte(skip)]
     name: CNameIndex,
@@ -278,11 +284,13 @@ impl Type {
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
+    /// kind
     pub fn kind(&self) -> TypeKind {
         self.kind
     }
@@ -297,6 +305,7 @@ impl From<Type> for Definition<'_> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TryRead, TryWrite, Measure)]
 #[byte(tag_type = u8)]
+/// Specifies the kind of a type.
 pub enum TypeKind {
     #[byte(tag = 0x00)]
     Primitive,
@@ -315,6 +324,7 @@ pub enum TypeKind {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a class definition.
 pub struct Class {
     #[byte(skip)]
     name: CNameIndex,
@@ -331,6 +341,7 @@ pub struct Class {
 }
 
 impl Class {
+    /// new
     pub fn new(name: CNameIndex, visiblity: Visibility, flags: ClassFlags) -> Self {
         Self {
             name,
@@ -344,72 +355,86 @@ impl Class {
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
+    /// visibility
     pub fn visibility(&self) -> Visibility {
         self.visiblity
     }
 
     #[inline]
+    /// flags
     pub fn flags(&self) -> ClassFlags {
         self.flags
     }
 
     #[inline]
+    /// base
     pub fn base(&self) -> Option<ClassIndex> {
         self.base
     }
 
     #[inline]
+    /// methods
     pub fn methods(&self) -> &[FunctionIndex] {
         &self.methods
     }
 
     #[inline]
+    /// fields
     pub fn fields(&self) -> &[FieldIndex] {
         &self.fields
     }
 
     #[inline]
+    /// fields_mut
     pub fn fields_mut(&mut self) -> &mut Vec<FieldIndex> {
         &mut self.fields
     }
 
     #[inline]
+    /// overrides
     pub fn overrides(&self) -> &[FieldIndex] {
         &self.overrides
     }
 
+    /// with_base
     pub fn with_base(mut self, base: Option<ClassIndex>) -> Self {
         self.base = base;
         self
     }
 
+    /// with_methods
     pub fn with_methods(mut self, methods: impl Into<Vec<FunctionIndex>>) -> Self {
         self.methods = methods.into();
         self.flags.set_has_functions(!self.methods.is_empty());
         self
     }
 
+    /// add_method
     pub fn add_method(&mut self, method: FunctionIndex) {
         self.methods.push(method);
         self.flags.set_has_functions(true);
     }
 
+    /// with_fields
     pub fn with_fields(mut self, fields: impl Into<Vec<FieldIndex>>) -> Self {
         self.fields = fields.into();
         self.flags.set_has_fields(!self.fields.is_empty());
         self
     }
 
+    /// add_field
     pub fn add_field(&mut self, field: FieldIndex) {
         self.fields.push(field);
         self.flags.set_has_fields(true);
     }
 
+    /// with_overrides
     pub fn with_overrides(mut self, overrides: impl Into<Vec<FieldIndex>>) -> Self {
         self.overrides = overrides.into();
         self.flags.set_has_overrides(!self.overrides.is_empty());
@@ -426,6 +451,7 @@ impl From<Class> for Definition<'_> {
 
 #[bitfield(u16)]
 #[derive(PartialEq, Eq)]
+/// Flags indicating properties of a class.
 pub struct ClassFlags {
     pub is_native: bool,
     pub is_abstract: bool,
@@ -443,6 +469,7 @@ pub struct ClassFlags {
 util::impl_bitfield_read_write!(ClassFlags);
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a member of an enumeration.
 pub struct EnumMember {
     #[byte(skip)]
     name: CNameIndex,
@@ -453,21 +480,25 @@ pub struct EnumMember {
 
 impl EnumMember {
     #[inline]
+    /// new
     pub fn new(name: CNameIndex, enum_: EnumIndex, value: i64) -> Self {
         Self { name, enum_, value }
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
+    /// enum_
     pub fn enum_(&self) -> EnumIndex {
         self.enum_
     }
 
     #[inline]
+    /// value
     pub fn value(&self) -> i64 {
         self.value
     }
@@ -481,6 +512,7 @@ impl From<EnumMember> for Definition<'_> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents an enumeration definition.
 pub struct Enum {
     #[byte(skip)]
     name: CNameIndex,
@@ -492,6 +524,7 @@ pub struct Enum {
 }
 
 impl Enum {
+    /// new
     pub fn new(name: CNameIndex, visiblity: Visibility, size: u8) -> Self {
         Self {
             name,
@@ -503,35 +536,42 @@ impl Enum {
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
+    /// visibility
     pub fn visibility(&self) -> Visibility {
         self.visiblity
     }
 
     #[inline]
+    /// size
     pub fn size(&self) -> u8 {
         self.size
     }
 
     #[inline]
+    /// values
     pub fn values(&self) -> &[EnumValueIndex] {
         &self.values
     }
 
     #[inline]
+    /// is_native
     pub fn is_native(&self) -> bool {
         self.is_native
     }
 
+    /// with_values
     pub fn with_values(mut self, values: impl Into<Vec<EnumValueIndex>>) -> Self {
         self.values = values.into();
         self
     }
 
+    /// with_is_native
     pub fn with_is_native(mut self, is_native: bool) -> Self {
         self.is_native = is_native;
         self
@@ -546,6 +586,7 @@ impl From<Enum> for Definition<'_> {
 }
 
 #[derive(Debug, Clone, PartialEq, TryRead, TryWrite, Measure)]
+/// Represents a function or method definition.
 pub struct Function<'i> {
     #[byte(skip)]
     name: CNameIndex,
@@ -574,6 +615,7 @@ pub struct Function<'i> {
 }
 
 impl<'i> Function<'i> {
+    /// new
     pub fn new(name: CNameIndex, visibility: Visibility, flags: FunctionFlags) -> Self {
         Self {
             name,
@@ -593,90 +635,108 @@ impl<'i> Function<'i> {
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
+    /// class
     pub fn class(&self) -> Option<ClassIndex> {
         self.class
     }
 
     #[inline]
+    /// visibility
     pub fn visibility(&self) -> Visibility {
         self.visibility
     }
 
     #[inline]
+    /// flags
     pub fn flags(&self) -> FunctionFlags {
         self.flags
     }
 
     #[inline]
+    /// source
     pub fn source(&self) -> Option<SourceReference> {
         self.source
     }
 
     #[inline]
+    /// return_type
     pub fn return_type(&self) -> Option<TypeIndex> {
         self.return_type
     }
 
     #[inline]
+    /// is_const_return
     pub fn is_const_return(&self) -> bool {
         self.is_const_return
     }
 
     #[inline]
+    /// base_method
     pub fn base_method(&self) -> Option<FunctionIndex> {
         self.base_method
     }
 
     #[inline]
+    /// parameters
     pub fn parameters(&self) -> &[ParameterIndex] {
         &self.parameters
     }
 
     #[inline]
+    /// parameters_mut
     pub fn parameters_mut(&mut self) -> &mut Vec<ParameterIndex> {
         &mut self.parameters
     }
 
     #[inline]
+    /// locals
     pub fn locals(&self) -> &[LocalIndex] {
         &self.locals
     }
 
     #[inline]
+    /// operator
     pub fn operator(&self) -> Option<CNameIndex> {
         self.operator
     }
 
     #[inline]
+    /// cast_cost
     pub fn cast_cost(&self) -> u8 {
         self.cast_cost
     }
 
     #[inline]
+    /// body
     pub fn body(&self) -> &FunctionBody<'i> {
         &self.body
     }
 
+    /// with_name
     pub fn with_name(mut self, name: CNameIndex) -> Self {
         self.name = name;
         self
     }
 
+    /// with_flags
     pub fn with_flags(mut self, flags: FunctionFlags) -> Self {
         self.flags = flags;
         self
     }
 
+    /// with_class
     pub fn with_class(mut self, class: Option<ClassIndex>) -> Self {
         self.class = class;
         self
     }
 
+    /// with_source
     pub fn with_source(mut self, source: Option<SourceReference>) -> Self {
         assert!(
             !self.flags.is_native() || source.is_none(),
@@ -686,60 +746,71 @@ impl<'i> Function<'i> {
         self
     }
 
+    /// with_return_type
     pub fn with_return_type(mut self, return_type: Option<TypeIndex>) -> Self {
         self.return_type = return_type;
         self.flags.set_has_return_value(return_type.is_some());
         self
     }
 
+    /// with_const_return_type
     pub fn with_const_return_type(mut self, return_type: TypeIndex) -> Self {
         self.is_const_return = true;
         self.with_return_type(Some(return_type))
     }
 
+    /// with_base_method
     pub fn with_base_method(mut self, base_method: Option<FunctionIndex>) -> Self {
         self.base_method = base_method;
         self.flags.set_has_base_method(base_method.is_some());
         self
     }
 
+    /// with_parameters
     pub fn with_parameters(mut self, parameters: impl Into<Vec<ParameterIndex>>) -> Self {
         self.parameters = parameters.into();
         self.flags.set_has_parameters(!self.parameters.is_empty());
         self
     }
 
+    /// with_locals
     pub fn with_locals(mut self, locals: impl Into<Vec<LocalIndex>>) -> Self {
         self.set_locals(locals);
         self
     }
 
+    /// set_locals
     pub fn set_locals(&mut self, locals: impl Into<Vec<LocalIndex>>) {
         self.locals = locals.into();
         self.flags.set_has_locals(!self.locals.is_empty());
     }
 
+    /// with_operator
     pub fn with_operator(mut self, operator: Option<CNameIndex>) -> Self {
         self.operator = operator;
         self.flags.set_is_operator(operator.is_some());
         self
     }
 
+    /// with_cast_cost
     pub fn with_cast_cost(mut self, cast_cost: u8) -> Self {
         self.cast_cost = cast_cost;
         self.flags.set_is_cast(cast_cost != 0);
         self
     }
 
+    /// with_body
     pub fn with_body(mut self, body: FunctionBody<'i>) -> Self {
         self.set_body(body);
         self
     }
 
+    /// with_code
     pub fn with_code(self, code: Vec<Instr>) -> Self {
         self.with_body(FunctionBody::Code(code))
     }
 
+    /// set_body
     pub fn set_body(&mut self, body: FunctionBody<'i>) {
         self.flags.set_has_body(!body.is_empty());
         if matches!(self.body, FunctionBody::Code(_)) {
@@ -748,10 +819,12 @@ impl<'i> Function<'i> {
         self.body = body;
     }
 
+    /// set_code
     pub fn set_code(&mut self, code: Vec<Instr>) {
         self.set_body(FunctionBody::Code(code));
     }
 
+    /// into_owned
     pub fn into_owned(self) -> Function<'static> {
         debug_assert_eq!(self.flags().has_base_method(), self.base_method.is_some());
         debug_assert_eq!(self.flags().has_return_value(), self.return_type.is_some());
@@ -789,6 +862,7 @@ impl<'i> From<Function<'i>> for Definition<'i> {
 
 #[bitfield(u32)]
 #[derive(PartialEq, Eq)]
+/// Flags indicating properties of a function.
 pub struct FunctionFlags {
     pub is_static: bool,
     pub is_exec: bool,
@@ -819,6 +893,7 @@ pub struct FunctionFlags {
 util::impl_bitfield_read_write!(FunctionFlags);
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a function parameter.
 pub struct Parameter {
     #[byte(skip)]
     name: CNameIndex,
@@ -830,6 +905,7 @@ pub struct Parameter {
 
 impl Parameter {
     #[inline]
+    /// new
     pub fn new(
         name: CNameIndex,
         function: FunctionIndex,
@@ -845,25 +921,30 @@ impl Parameter {
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
+    /// function
     pub fn function(&self) -> FunctionIndex {
         self.function
     }
 
     #[inline]
+    /// type_
     pub fn type_(&self) -> TypeIndex {
         self.type_
     }
 
     #[inline]
+    /// flags
     pub fn flags(&self) -> ParameterFlags {
         self.flags
     }
 
+    /// with_function
     pub fn with_function(mut self, function: FunctionIndex) -> Self {
         self.function = function;
         self
@@ -879,6 +960,7 @@ impl From<Parameter> for Definition<'_> {
 
 #[bitfield(u8)]
 #[derive(PartialEq, Eq)]
+/// Flags indicating properties of a parameter.
 pub struct ParameterFlags {
     pub is_optional: bool,
     pub is_out: bool,
@@ -891,6 +973,7 @@ pub struct ParameterFlags {
 util::impl_bitfield_read_write!(ParameterFlags);
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a local variable in a function.
 pub struct Local {
     #[byte(skip)]
     name: CNameIndex,
@@ -902,6 +985,7 @@ pub struct Local {
 
 impl Local {
     #[inline]
+    /// new
     pub fn new(
         name: CNameIndex,
         function: FunctionIndex,
@@ -917,25 +1001,30 @@ impl Local {
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
+    /// function
     pub fn function(&self) -> FunctionIndex {
         self.function
     }
 
     #[inline]
+    /// type_
     pub fn type_(&self) -> TypeIndex {
         self.type_
     }
 
     #[inline]
+    /// flags
     pub fn flags(&self) -> LocalFlags {
         self.flags
     }
 
+    /// with_function
     pub fn with_function(mut self, function: FunctionIndex) -> Self {
         self.function = function;
         self
@@ -951,6 +1040,7 @@ impl From<Local> for Definition<'_> {
 
 #[bitfield(u8)]
 #[derive(PartialEq, Eq)]
+/// Flags indicating properties of a local variable.
 pub struct LocalFlags {
     pub is_const: bool,
     #[bits(7)]
@@ -960,6 +1050,7 @@ pub struct LocalFlags {
 util::impl_bitfield_read_write!(LocalFlags);
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a field in a class or struct.
 pub struct Field<'i> {
     #[byte(skip)]
     name: CNameIndex,
@@ -977,6 +1068,7 @@ pub struct Field<'i> {
 }
 
 impl<'i> Field<'i> {
+    /// new
     pub fn new(
         name: CNameIndex,
         class: ClassIndex,
@@ -997,66 +1089,79 @@ impl<'i> Field<'i> {
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
+    /// class
     pub fn class(&self) -> ClassIndex {
         self.class
     }
 
     #[inline]
+    /// visibility
     pub fn visibility(&self) -> Visibility {
         self.visibility
     }
 
     #[inline]
+    /// type_
     pub fn type_(&self) -> TypeIndex {
         self.type_
     }
 
     #[inline]
+    /// flags
     pub fn flags(&self) -> FieldFlags {
         self.flags
     }
 
     #[inline]
+    /// hint
     pub fn hint(&self) -> Option<&str> {
         self.hint.as_deref()
     }
 
     #[inline]
+    /// attributes
     pub fn attributes(&self) -> &[Property<'i>] {
         &self.attributes
     }
 
     #[inline]
+    /// defaults
     pub fn defaults(&self) -> &[Property<'i>] {
         &self.defaults
     }
 
+    /// with_hint
     pub fn with_hint(mut self, hint: impl Into<Str<'i>>) -> Self {
         self.hint = Some(hint.into());
         self.flags.set_has_hint(true);
         self
     }
 
+    /// with_attributes
     pub fn with_attributes(mut self, attributes: impl Into<Vec<Property<'i>>>) -> Self {
         self.attributes = attributes.into();
         self
     }
 
+    /// with_defaults
     pub fn with_defaults(mut self, defaults: impl Into<Vec<Property<'i>>>) -> Self {
         self.set_defaults(defaults);
         self
     }
 
+    /// set_defaults
     pub fn set_defaults(&mut self, defaults: impl Into<Vec<Property<'i>>>) {
         self.defaults = defaults.into();
         self.flags.set_has_default(!self.defaults.is_empty());
     }
 
+    /// into_owned
     pub fn into_owned(self) -> Field<'static> {
         Field {
             name: self.name,
@@ -1087,6 +1192,7 @@ impl<'i> From<Field<'i>> for Definition<'i> {
 
 #[bitfield(u16)]
 #[derive(PartialEq, Eq)]
+/// Flags indicating properties of a field.
 pub struct FieldFlags {
     pub is_native: bool,
     pub is_editable: bool,
@@ -1106,6 +1212,7 @@ pub struct FieldFlags {
 util::impl_bitfield_read_write!(FieldFlags);
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a source file reference.
 pub struct SourceFile<'i> {
     index: u32,
     path_hash: u32,
@@ -1116,6 +1223,7 @@ pub struct SourceFile<'i> {
 
 impl<'i> SourceFile<'i> {
     #[inline]
+    /// new
     pub fn new(index: u32, path_hash: u32, code_crc: u32, path: impl Into<Str<'i>>) -> Self {
         Self {
             index,
@@ -1126,25 +1234,30 @@ impl<'i> SourceFile<'i> {
     }
 
     #[inline]
+    /// index
     pub fn index(&self) -> u32 {
         self.index
     }
 
     #[inline]
+    /// path_hash
     pub fn path_hash(&self) -> u32 {
         self.path_hash
     }
 
     #[inline]
+    /// code_crc
     pub fn code_crc(&self) -> u32 {
         self.code_crc
     }
 
     #[inline]
+    /// path
     pub fn path(&self) -> &str {
         &self.path
     }
 
+    /// into_owned
     pub fn into_owned(self) -> SourceFile<'static> {
         SourceFile {
             index: self.index,
@@ -1163,6 +1276,7 @@ impl<'i> From<SourceFile<'i>> for Definition<'i> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// Represents the body of a function.
 pub enum FunctionBody<'i> {
     Raw {
         max_offset: u32,
@@ -1172,6 +1286,7 @@ pub enum FunctionBody<'i> {
 }
 
 impl FunctionBody<'_> {
+    /// is_empty
     pub fn is_empty(&self) -> bool {
         match self {
             &FunctionBody::Raw { max_offset, .. } => max_offset == 0,
@@ -1179,6 +1294,7 @@ impl FunctionBody<'_> {
         }
     }
 
+    /// into_owned
     pub fn into_owned(self) -> FunctionBody<'static> {
         match self {
             FunctionBody::Raw { max_offset, bytes } => FunctionBody::Raw {
@@ -1190,10 +1306,12 @@ impl FunctionBody<'_> {
     }
 
     #[inline]
+    /// code_iter
     pub fn code_iter(&self) -> FunctionBodyIter<'_> {
         FunctionBodyIter::new(self)
     }
 
+    /// code_owned
     pub fn code_owned(&self) -> byte::Result<Vec<Instr>> {
         match self {
             FunctionBody::Raw { .. } => self.code_iter().collect::<Result<Vec<_>, _>>(),
@@ -1271,6 +1389,7 @@ impl<Ctx: Copy> Measure<(Ctx, FunctionFlags)> for FunctionBody<'_> {
 }
 
 #[derive(Debug, Clone)]
+/// An iterator over the body of a function.
 pub enum FunctionBodyIter<'a> {
     Raw {
         virtual_offset: u32,
@@ -1292,6 +1411,7 @@ impl<'a> FunctionBodyIter<'a> {
         }
     }
 
+    /// virtual_offset
     pub fn virtual_offset(&self) -> u32 {
         match self {
             FunctionBodyIter::Raw {
@@ -1305,6 +1425,7 @@ impl<'a> FunctionBodyIter<'a> {
         }
     }
 
+    /// with_offsets
     pub fn with_offsets(mut self) -> impl Iterator<Item = (u32, byte::Result<Instr>)> + use<'a> {
         iter::from_fn(move || Some((self.virtual_offset(), self.next()?)))
     }
@@ -1340,6 +1461,7 @@ impl Iterator for FunctionBodyIter<'_> {
 impl iter::FusedIterator for FunctionBodyIter<'_> {}
 
 #[derive(Debug, Clone)]
+/// An iterator over a sequence of instructions.
 pub struct CodeIter<'a, L> {
     virtual_offset: u32,
     instructions: &'a [Instr<L>],
@@ -1347,6 +1469,7 @@ pub struct CodeIter<'a, L> {
 
 impl<'a, L> CodeIter<'a, L> {
     #[inline]
+    /// new
     pub fn new(instructions: &'a [Instr<L>]) -> Self {
         Self {
             virtual_offset: 0,
@@ -1355,15 +1478,18 @@ impl<'a, L> CodeIter<'a, L> {
     }
 
     #[inline]
+    /// virtual_offset
     pub fn virtual_offset(&self) -> u32 {
         self.virtual_offset
     }
 
+    /// with_offsets
     pub fn with_offsets(mut self) -> impl Iterator<Item = (u32, &'a Instr<L>)> {
         iter::from_fn(move || Some((self.virtual_offset(), self.next()?)))
     }
 
     #[inline]
+    /// as_slice
     pub fn as_slice(&self) -> &'a [Instr<L>] {
         self.instructions
     }
@@ -1381,6 +1507,7 @@ impl<'a, L> Iterator for CodeIter<'a, L> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a property attached to a definition.
 pub struct Property<'i> {
     #[byte(ctx = Prefixed(ctx))]
     name: Str<'i>,
@@ -1390,6 +1517,7 @@ pub struct Property<'i> {
 
 impl<'i> Property<'i> {
     #[inline]
+    /// new
     pub fn new(name: impl Into<Str<'i>>, value: impl Into<Str<'i>>) -> Self {
         Self {
             name: name.into(),
@@ -1398,15 +1526,18 @@ impl<'i> Property<'i> {
     }
 
     #[inline]
+    /// name
     pub fn name(&self) -> &str {
         &self.name
     }
 
     #[inline]
+    /// value
     pub fn value(&self) -> &str {
         &self.value
     }
 
+    /// into_owned
     pub fn into_owned(self) -> Property<'static> {
         Property {
             name: self.name.into_owned().into(),
@@ -1416,6 +1547,7 @@ impl<'i> Property<'i> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// A reference to a location in a source file.
 pub struct SourceReference {
     file: SourceFileIndex,
     line: u32,
@@ -1428,16 +1560,19 @@ impl SourceReference {
     };
 
     #[inline]
+    /// new
     pub fn new(file: SourceFileIndex, line: u32) -> Self {
         Self { file, line }
     }
 
     #[inline]
+    /// file
     pub fn file(&self) -> SourceFileIndex {
         self.file
     }
 
     #[inline]
+    /// line
     pub fn line(&self) -> u32 {
         self.line
     }
@@ -1445,6 +1580,7 @@ impl SourceReference {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, TryRead, TryWrite, Measure)]
 #[byte(tag_type = u8)]
+/// Specifies the visibility of a definition.
 pub enum Visibility {
     #[default]
     #[byte(tag = 0x00)]
@@ -1455,6 +1591,7 @@ pub enum Visibility {
     Private,
 }
 
+/// A trait for types that can be created from a `u32` pool index.
 pub trait IndexType: Copy {
     fn from_u32(value: u32) -> Option<Self>;
 }
@@ -1473,6 +1610,7 @@ impl<A> IndexType for NzPoolIndex<A> {
     }
 }
 
+/// A trait for types that can be converted into a `Definition`.
 pub trait DefinitionIndex<'i>: Into<Definition<'i>> {
     type Index: IndexType;
 }

--- a/crates/io/src/definition.rs
+++ b/crates/io/src/definition.rs
@@ -77,7 +77,7 @@ impl Definition<'_> {
         }
     }
 
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         match self {
             Definition::Type(t) => t.name,
@@ -107,7 +107,7 @@ impl Definition<'_> {
         }
     }
 
-    /// into_owned
+    /// Converts this definition into an owned version.
     pub fn into_owned(self) -> Definition<'static> {
         match self {
             Definition::Type(t) => Definition::Type(t),
@@ -284,13 +284,13 @@ impl Type {
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
-    /// kind
+    /// Gets the kind of this type.
     pub fn kind(&self) -> TypeKind {
         self.kind
     }
@@ -341,7 +341,7 @@ pub struct Class {
 }
 
 impl Class {
-    /// new
+    /// Creates a new instance.
     pub fn new(name: CNameIndex, visiblity: Visibility, flags: ClassFlags) -> Self {
         Self {
             name,
@@ -355,86 +355,86 @@ impl Class {
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
-    /// visibility
+    /// Gets the visibility.
     pub fn visibility(&self) -> Visibility {
         self.visiblity
     }
 
     #[inline]
-    /// flags
+    /// Gets the flags.
     pub fn flags(&self) -> ClassFlags {
         self.flags
     }
 
     #[inline]
-    /// base
+    /// Gets the base class index.
     pub fn base(&self) -> Option<ClassIndex> {
         self.base
     }
 
     #[inline]
-    /// methods
+    /// Gets the list of methods.
     pub fn methods(&self) -> &[FunctionIndex] {
         &self.methods
     }
 
     #[inline]
-    /// fields
+    /// Gets the list of fields.
     pub fn fields(&self) -> &[FieldIndex] {
         &self.fields
     }
 
     #[inline]
-    /// fields_mut
+    /// Gets a mutable list of fields.
     pub fn fields_mut(&mut self) -> &mut Vec<FieldIndex> {
         &mut self.fields
     }
 
     #[inline]
-    /// overrides
+    /// Gets the list of overrides.
     pub fn overrides(&self) -> &[FieldIndex] {
         &self.overrides
     }
 
-    /// with_base
+    /// Returns a copy of this object with the `base` updated.
     pub fn with_base(mut self, base: Option<ClassIndex>) -> Self {
         self.base = base;
         self
     }
 
-    /// with_methods
+    /// Returns a copy of this object with the `methods` updated.
     pub fn with_methods(mut self, methods: impl Into<Vec<FunctionIndex>>) -> Self {
         self.methods = methods.into();
         self.flags.set_has_functions(!self.methods.is_empty());
         self
     }
 
-    /// add_method
+    /// Adds to the `methods` of this object.
     pub fn add_method(&mut self, method: FunctionIndex) {
         self.methods.push(method);
         self.flags.set_has_functions(true);
     }
 
-    /// with_fields
+    /// Returns a copy of this object with the `fields` updated.
     pub fn with_fields(mut self, fields: impl Into<Vec<FieldIndex>>) -> Self {
         self.fields = fields.into();
         self.flags.set_has_fields(!self.fields.is_empty());
         self
     }
 
-    /// add_field
+    /// Adds to the `fields` of this object.
     pub fn add_field(&mut self, field: FieldIndex) {
         self.fields.push(field);
         self.flags.set_has_fields(true);
     }
 
-    /// with_overrides
+    /// Returns a copy of this object with the `overrides` updated.
     pub fn with_overrides(mut self, overrides: impl Into<Vec<FieldIndex>>) -> Self {
         self.overrides = overrides.into();
         self.flags.set_has_overrides(!self.overrides.is_empty());
@@ -480,25 +480,25 @@ pub struct EnumMember {
 
 impl EnumMember {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(name: CNameIndex, enum_: EnumIndex, value: i64) -> Self {
         Self { name, enum_, value }
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
-    /// enum_
+    /// Gets the enum index.
     pub fn enum_(&self) -> EnumIndex {
         self.enum_
     }
 
     #[inline]
-    /// value
+    /// Gets the value.
     pub fn value(&self) -> i64 {
         self.value
     }
@@ -524,7 +524,7 @@ pub struct Enum {
 }
 
 impl Enum {
-    /// new
+    /// Creates a new instance.
     pub fn new(name: CNameIndex, visiblity: Visibility, size: u8) -> Self {
         Self {
             name,
@@ -536,42 +536,42 @@ impl Enum {
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
-    /// visibility
+    /// Gets the visibility.
     pub fn visibility(&self) -> Visibility {
         self.visiblity
     }
 
     #[inline]
-    /// size
+    /// Gets the size.
     pub fn size(&self) -> u8 {
         self.size
     }
 
     #[inline]
-    /// values
+    /// Gets the list of enum values.
     pub fn values(&self) -> &[EnumValueIndex] {
         &self.values
     }
 
     #[inline]
-    /// is_native
+    /// Returns whether this is native.
     pub fn is_native(&self) -> bool {
         self.is_native
     }
 
-    /// with_values
+    /// Returns a copy of this object with the `values` updated.
     pub fn with_values(mut self, values: impl Into<Vec<EnumValueIndex>>) -> Self {
         self.values = values.into();
         self
     }
 
-    /// with_is_native
+    /// Returns a copy of this object with the `is_native` updated.
     pub fn with_is_native(mut self, is_native: bool) -> Self {
         self.is_native = is_native;
         self
@@ -615,7 +615,7 @@ pub struct Function<'i> {
 }
 
 impl<'i> Function<'i> {
-    /// new
+    /// Creates a new instance.
     pub fn new(name: CNameIndex, visibility: Visibility, flags: FunctionFlags) -> Self {
         Self {
             name,
@@ -635,108 +635,108 @@ impl<'i> Function<'i> {
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
-    /// class
+    /// Gets the class index.
     pub fn class(&self) -> Option<ClassIndex> {
         self.class
     }
 
     #[inline]
-    /// visibility
+    /// Gets the visibility.
     pub fn visibility(&self) -> Visibility {
         self.visibility
     }
 
     #[inline]
-    /// flags
+    /// Gets the flags.
     pub fn flags(&self) -> FunctionFlags {
         self.flags
     }
 
     #[inline]
-    /// source
+    /// Gets the source reference.
     pub fn source(&self) -> Option<SourceReference> {
         self.source
     }
 
     #[inline]
-    /// return_type
+    /// Gets the return type.
     pub fn return_type(&self) -> Option<TypeIndex> {
         self.return_type
     }
 
     #[inline]
-    /// is_const_return
+    /// Returns whether the return type is const.
     pub fn is_const_return(&self) -> bool {
         self.is_const_return
     }
 
     #[inline]
-    /// base_method
+    /// Gets the base method index.
     pub fn base_method(&self) -> Option<FunctionIndex> {
         self.base_method
     }
 
     #[inline]
-    /// parameters
+    /// Gets the list of parameters.
     pub fn parameters(&self) -> &[ParameterIndex] {
         &self.parameters
     }
 
     #[inline]
-    /// parameters_mut
+    /// Gets a mutable list of parameters.
     pub fn parameters_mut(&mut self) -> &mut Vec<ParameterIndex> {
         &mut self.parameters
     }
 
     #[inline]
-    /// locals
+    /// Gets the list of local variables.
     pub fn locals(&self) -> &[LocalIndex] {
         &self.locals
     }
 
     #[inline]
-    /// operator
+    /// Gets the operator.
     pub fn operator(&self) -> Option<CNameIndex> {
         self.operator
     }
 
     #[inline]
-    /// cast_cost
+    /// Gets the cast cost.
     pub fn cast_cost(&self) -> u8 {
         self.cast_cost
     }
 
     #[inline]
-    /// body
+    /// Gets the function body.
     pub fn body(&self) -> &FunctionBody<'i> {
         &self.body
     }
 
-    /// with_name
+    /// Returns a copy of this object with the `name` updated.
     pub fn with_name(mut self, name: CNameIndex) -> Self {
         self.name = name;
         self
     }
 
-    /// with_flags
+    /// Returns a copy of this object with the `flags` updated.
     pub fn with_flags(mut self, flags: FunctionFlags) -> Self {
         self.flags = flags;
         self
     }
 
-    /// with_class
+    /// Returns a copy of this object with the `class` updated.
     pub fn with_class(mut self, class: Option<ClassIndex>) -> Self {
         self.class = class;
         self
     }
 
-    /// with_source
+    /// Returns a copy of this object with the `source` updated.
     pub fn with_source(mut self, source: Option<SourceReference>) -> Self {
         assert!(
             !self.flags.is_native() || source.is_none(),
@@ -746,71 +746,71 @@ impl<'i> Function<'i> {
         self
     }
 
-    /// with_return_type
+    /// Returns a copy of this object with the `return_type` updated.
     pub fn with_return_type(mut self, return_type: Option<TypeIndex>) -> Self {
         self.return_type = return_type;
         self.flags.set_has_return_value(return_type.is_some());
         self
     }
 
-    /// with_const_return_type
+    /// Returns a copy of this object with the `const_return_type` updated.
     pub fn with_const_return_type(mut self, return_type: TypeIndex) -> Self {
         self.is_const_return = true;
         self.with_return_type(Some(return_type))
     }
 
-    /// with_base_method
+    /// Returns a copy of this object with the `base_method` updated.
     pub fn with_base_method(mut self, base_method: Option<FunctionIndex>) -> Self {
         self.base_method = base_method;
         self.flags.set_has_base_method(base_method.is_some());
         self
     }
 
-    /// with_parameters
+    /// Returns a copy of this object with the `parameters` updated.
     pub fn with_parameters(mut self, parameters: impl Into<Vec<ParameterIndex>>) -> Self {
         self.parameters = parameters.into();
         self.flags.set_has_parameters(!self.parameters.is_empty());
         self
     }
 
-    /// with_locals
+    /// Returns a copy of this object with the `locals` updated.
     pub fn with_locals(mut self, locals: impl Into<Vec<LocalIndex>>) -> Self {
         self.set_locals(locals);
         self
     }
 
-    /// set_locals
+    /// Sets the `locals` of this object.
     pub fn set_locals(&mut self, locals: impl Into<Vec<LocalIndex>>) {
         self.locals = locals.into();
         self.flags.set_has_locals(!self.locals.is_empty());
     }
 
-    /// with_operator
+    /// Returns a copy of this object with the `operator` updated.
     pub fn with_operator(mut self, operator: Option<CNameIndex>) -> Self {
         self.operator = operator;
         self.flags.set_is_operator(operator.is_some());
         self
     }
 
-    /// with_cast_cost
+    /// Returns a copy of this object with the `cast_cost` updated.
     pub fn with_cast_cost(mut self, cast_cost: u8) -> Self {
         self.cast_cost = cast_cost;
         self.flags.set_is_cast(cast_cost != 0);
         self
     }
 
-    /// with_body
+    /// Returns a copy of this object with the `body` updated.
     pub fn with_body(mut self, body: FunctionBody<'i>) -> Self {
         self.set_body(body);
         self
     }
 
-    /// with_code
+    /// Returns a copy of this object with the `code` updated.
     pub fn with_code(self, code: Vec<Instr>) -> Self {
         self.with_body(FunctionBody::Code(code))
     }
 
-    /// set_body
+    /// Sets the `body` of this object.
     pub fn set_body(&mut self, body: FunctionBody<'i>) {
         self.flags.set_has_body(!body.is_empty());
         if matches!(self.body, FunctionBody::Code(_)) {
@@ -819,12 +819,12 @@ impl<'i> Function<'i> {
         self.body = body;
     }
 
-    /// set_code
+    /// Sets the `code` of this object.
     pub fn set_code(&mut self, code: Vec<Instr>) {
         self.set_body(FunctionBody::Code(code));
     }
 
-    /// into_owned
+    /// Converts this definition into an owned version.
     pub fn into_owned(self) -> Function<'static> {
         debug_assert_eq!(self.flags().has_base_method(), self.base_method.is_some());
         debug_assert_eq!(self.flags().has_return_value(), self.return_type.is_some());
@@ -905,7 +905,7 @@ pub struct Parameter {
 
 impl Parameter {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(
         name: CNameIndex,
         function: FunctionIndex,
@@ -921,30 +921,30 @@ impl Parameter {
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
-    /// function
+    /// Gets the function index.
     pub fn function(&self) -> FunctionIndex {
         self.function
     }
 
     #[inline]
-    /// type_
+    /// Gets the type index.
     pub fn type_(&self) -> TypeIndex {
         self.type_
     }
 
     #[inline]
-    /// flags
+    /// Gets the flags.
     pub fn flags(&self) -> ParameterFlags {
         self.flags
     }
 
-    /// with_function
+    /// Returns a copy of this object with the `function` updated.
     pub fn with_function(mut self, function: FunctionIndex) -> Self {
         self.function = function;
         self
@@ -985,7 +985,7 @@ pub struct Local {
 
 impl Local {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(
         name: CNameIndex,
         function: FunctionIndex,
@@ -1001,30 +1001,30 @@ impl Local {
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
-    /// function
+    /// Gets the function index.
     pub fn function(&self) -> FunctionIndex {
         self.function
     }
 
     #[inline]
-    /// type_
+    /// Gets the type index.
     pub fn type_(&self) -> TypeIndex {
         self.type_
     }
 
     #[inline]
-    /// flags
+    /// Gets the flags.
     pub fn flags(&self) -> LocalFlags {
         self.flags
     }
 
-    /// with_function
+    /// Returns a copy of this object with the `function` updated.
     pub fn with_function(mut self, function: FunctionIndex) -> Self {
         self.function = function;
         self
@@ -1068,7 +1068,7 @@ pub struct Field<'i> {
 }
 
 impl<'i> Field<'i> {
-    /// new
+    /// Creates a new instance.
     pub fn new(
         name: CNameIndex,
         class: ClassIndex,
@@ -1089,79 +1089,79 @@ impl<'i> Field<'i> {
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> CNameIndex {
         self.name
     }
 
     #[inline]
-    /// class
+    /// Gets the class index.
     pub fn class(&self) -> ClassIndex {
         self.class
     }
 
     #[inline]
-    /// visibility
+    /// Gets the visibility.
     pub fn visibility(&self) -> Visibility {
         self.visibility
     }
 
     #[inline]
-    /// type_
+    /// Gets the type index.
     pub fn type_(&self) -> TypeIndex {
         self.type_
     }
 
     #[inline]
-    /// flags
+    /// Gets the flags.
     pub fn flags(&self) -> FieldFlags {
         self.flags
     }
 
     #[inline]
-    /// hint
+    /// Gets the hint string.
     pub fn hint(&self) -> Option<&str> {
         self.hint.as_deref()
     }
 
     #[inline]
-    /// attributes
+    /// Gets the attributes.
     pub fn attributes(&self) -> &[Property<'i>] {
         &self.attributes
     }
 
     #[inline]
-    /// defaults
+    /// Gets the default values.
     pub fn defaults(&self) -> &[Property<'i>] {
         &self.defaults
     }
 
-    /// with_hint
+    /// Returns a copy of this object with the `hint` updated.
     pub fn with_hint(mut self, hint: impl Into<Str<'i>>) -> Self {
         self.hint = Some(hint.into());
         self.flags.set_has_hint(true);
         self
     }
 
-    /// with_attributes
+    /// Returns a copy of this object with the `attributes` updated.
     pub fn with_attributes(mut self, attributes: impl Into<Vec<Property<'i>>>) -> Self {
         self.attributes = attributes.into();
         self
     }
 
-    /// with_defaults
+    /// Returns a copy of this object with the `defaults` updated.
     pub fn with_defaults(mut self, defaults: impl Into<Vec<Property<'i>>>) -> Self {
         self.set_defaults(defaults);
         self
     }
 
-    /// set_defaults
+    /// Sets the `defaults` of this object.
     pub fn set_defaults(&mut self, defaults: impl Into<Vec<Property<'i>>>) {
         self.defaults = defaults.into();
         self.flags.set_has_default(!self.defaults.is_empty());
     }
 
-    /// into_owned
+    /// Converts this definition into an owned version.
     pub fn into_owned(self) -> Field<'static> {
         Field {
             name: self.name,
@@ -1223,7 +1223,7 @@ pub struct SourceFile<'i> {
 
 impl<'i> SourceFile<'i> {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(index: u32, path_hash: u32, code_crc: u32, path: impl Into<Str<'i>>) -> Self {
         Self {
             index,
@@ -1234,30 +1234,30 @@ impl<'i> SourceFile<'i> {
     }
 
     #[inline]
-    /// index
+    /// Gets the pool index.
     pub fn index(&self) -> u32 {
         self.index
     }
 
     #[inline]
-    /// path_hash
+    /// Gets the hash of the path.
     pub fn path_hash(&self) -> u32 {
         self.path_hash
     }
 
     #[inline]
-    /// code_crc
+    /// Gets the CRC of the code.
     pub fn code_crc(&self) -> u32 {
         self.code_crc
     }
 
     #[inline]
-    /// path
+    /// Gets the file path.
     pub fn path(&self) -> &str {
         &self.path
     }
 
-    /// into_owned
+    /// Converts this definition into an owned version.
     pub fn into_owned(self) -> SourceFile<'static> {
         SourceFile {
             index: self.index,
@@ -1286,7 +1286,7 @@ pub enum FunctionBody<'i> {
 }
 
 impl FunctionBody<'_> {
-    /// is_empty
+    /// Returns true if this is empty.
     pub fn is_empty(&self) -> bool {
         match self {
             &FunctionBody::Raw { max_offset, .. } => max_offset == 0,
@@ -1294,7 +1294,7 @@ impl FunctionBody<'_> {
         }
     }
 
-    /// into_owned
+    /// Converts this definition into an owned version.
     pub fn into_owned(self) -> FunctionBody<'static> {
         match self {
             FunctionBody::Raw { max_offset, bytes } => FunctionBody::Raw {
@@ -1306,12 +1306,12 @@ impl FunctionBody<'_> {
     }
 
     #[inline]
-    /// code_iter
+    /// Returns an iterator over the code instructions.
     pub fn code_iter(&self) -> FunctionBodyIter<'_> {
         FunctionBodyIter::new(self)
     }
 
-    /// code_owned
+    /// Returns an owned vector of the code instructions.
     pub fn code_owned(&self) -> byte::Result<Vec<Instr>> {
         match self {
             FunctionBody::Raw { .. } => self.code_iter().collect::<Result<Vec<_>, _>>(),
@@ -1411,7 +1411,7 @@ impl<'a> FunctionBodyIter<'a> {
         }
     }
 
-    /// virtual_offset
+    /// Gets the current virtual offset.
     pub fn virtual_offset(&self) -> u32 {
         match self {
             FunctionBodyIter::Raw {
@@ -1425,7 +1425,7 @@ impl<'a> FunctionBodyIter<'a> {
         }
     }
 
-    /// with_offsets
+    /// Returns an iterator yielding virtual offsets and instructions.
     pub fn with_offsets(mut self) -> impl Iterator<Item = (u32, byte::Result<Instr>)> + use<'a> {
         iter::from_fn(move || Some((self.virtual_offset(), self.next()?)))
     }
@@ -1469,7 +1469,7 @@ pub struct CodeIter<'a, L> {
 
 impl<'a, L> CodeIter<'a, L> {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(instructions: &'a [Instr<L>]) -> Self {
         Self {
             virtual_offset: 0,
@@ -1478,18 +1478,18 @@ impl<'a, L> CodeIter<'a, L> {
     }
 
     #[inline]
-    /// virtual_offset
+    /// Gets the current virtual offset.
     pub fn virtual_offset(&self) -> u32 {
         self.virtual_offset
     }
 
-    /// with_offsets
+    /// Returns an iterator yielding virtual offsets and instructions.
     pub fn with_offsets(mut self) -> impl Iterator<Item = (u32, &'a Instr<L>)> {
         iter::from_fn(move || Some((self.virtual_offset(), self.next()?)))
     }
 
     #[inline]
-    /// as_slice
+    /// Returns the instructions as a slice.
     pub fn as_slice(&self) -> &'a [Instr<L>] {
         self.instructions
     }
@@ -1517,7 +1517,7 @@ pub struct Property<'i> {
 
 impl<'i> Property<'i> {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(name: impl Into<Str<'i>>, value: impl Into<Str<'i>>) -> Self {
         Self {
             name: name.into(),
@@ -1526,18 +1526,18 @@ impl<'i> Property<'i> {
     }
 
     #[inline]
-    /// name
+    /// Gets the name index of this definition.
     pub fn name(&self) -> &str {
         &self.name
     }
 
     #[inline]
-    /// value
+    /// Gets the value.
     pub fn value(&self) -> &str {
         &self.value
     }
 
-    /// into_owned
+    /// Converts this definition into an owned version.
     pub fn into_owned(self) -> Property<'static> {
         Property {
             name: self.name.into_owned().into(),
@@ -1560,19 +1560,19 @@ impl SourceReference {
     };
 
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(file: SourceFileIndex, line: u32) -> Self {
         Self { file, line }
     }
 
     #[inline]
-    /// file
+    /// Gets the source file reference.
     pub fn file(&self) -> SourceFileIndex {
         self.file
     }
 
     #[inline]
-    /// line
+    /// Gets the line number.
     pub fn line(&self) -> u32 {
         self.line
     }

--- a/crates/io/src/instr.rs
+++ b/crates/io/src/instr.rs
@@ -11,83 +11,121 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, TryRead, TryWrite, Measure)]
 #[byte(tag_type = u8)]
+/// Represents a single operation or instruction in the REDengine bytecode.
 pub enum Instr<Loc = Offset> {
     #[byte(tag = 0x00)]
+    /// No operation.
     Nop,
     #[byte(tag = 0x01)]
+    /// Pushes a null reference onto the stack.
     Null,
     #[byte(tag = 0x02)]
+    /// Pushes the 32-bit integer `1` onto the stack.
     I32One,
     #[byte(tag = 0x03)]
+    /// Pushes the 32-bit integer `0` onto the stack.
     I32Zero,
     #[byte(tag = 0x04)]
+    /// Pushes an 8-bit integer constant onto the stack.
     I8Const(i8),
     #[byte(tag = 0x05)]
+    /// Pushes a 16-bit integer constant onto the stack.
     I16Const(i16),
     #[byte(tag = 0x06)]
+    /// Pushes a 32-bit integer constant onto the stack.
     I32Const(i32),
     #[byte(tag = 0x07)]
+    /// Pushes a 64-bit integer constant onto the stack.
     I64Const(i64),
     #[byte(tag = 0x08)]
+    /// Pushes an unsigned 8-bit integer constant onto the stack.
     U8Const(u8),
     #[byte(tag = 0x09)]
+    /// Pushes an unsigned 16-bit integer constant onto the stack.
     U16Const(u16),
     #[byte(tag = 0x0A)]
+    /// Pushes an unsigned 32-bit integer constant onto the stack.
     U32Const(u32),
     #[byte(tag = 0x0B)]
+    /// Pushes an unsigned 64-bit integer constant onto the stack.
     U64Const(u64),
     #[byte(tag = 0x0C)]
+    /// Pushes a 32-bit floating point constant onto the stack.
     F32Const(f32),
     #[byte(tag = 0x0D)]
+    /// Pushes a 64-bit floating point constant onto the stack.
     F64Const(f64),
     #[byte(tag = 0x0E)]
+    /// Pushes a name (CName) constant onto the stack.
     CNameConst(CNameIndex),
     #[byte(tag = 0x0F)]
+    /// Pushes an enumeration constant onto the stack.
     EnumConst {
         enum_: EnumIndex,
         value: EnumValueIndex,
     },
     #[byte(tag = 0x10)]
+    /// Pushes a string constant onto the stack.
     StringConst(StringIndex),
     #[byte(tag = 0x11)]
+    /// Pushes a TweakDB ID constant onto the stack.
     TweakDbIdConst(TweakDbIndex),
     #[byte(tag = 0x12)]
+    /// Pushes a resource reference constant onto the stack.
     ResourceConst(ResourceIndex),
     #[byte(tag = 0x13)]
+    /// Pushes the boolean value `true` onto the stack.
     TrueConst,
     #[byte(tag = 0x14)]
+    /// Pushes the boolean value `false` onto the stack.
     FalseConst,
     #[byte(tag = 0x15)]
+    /// Triggers a breakpoint during execution.
     Breakpoint(Box<Breakpoint>),
     #[byte(tag = 0x16)]
+    /// Assigns a value to a local variable or field.
     Assign,
     #[byte(tag = 0x17)]
+    /// Defines a jump target.
     Target(Loc),
     #[byte(tag = 0x18)]
+    /// Pushes a reference to a local variable onto the stack.
     Local(LocalIndex),
     #[byte(tag = 0x19)]
+    /// Pushes a reference to a parameter onto the stack.
     Param(ParameterIndex),
     #[byte(tag = 0x1A)]
+    /// Accesses a field of an object.
     ObjectField(FieldIndex),
     #[byte(tag = 0x1B)]
+    /// Accesses an external variable.
     ExternalVar,
     #[byte(tag = 0x1C)]
+    /// Initiates a switch statement.
     Switch(Switch<Loc>),
     #[byte(tag = 0x1D)]
+    /// Defines a label within a switch statement.
     SwitchLabel(SwitchLabel<Loc>),
     #[byte(tag = 0x1E)]
+    /// Defines the default case of a switch statement.
     SwitchDefault,
     #[byte(tag = 0x1F)]
+    /// Unconditionally jumps to a target location.
     Jump(Jump<Loc>),
     #[byte(tag = 0x20)]
+    /// Jumps to a target location if the condition is false.
     JumpIfFalse(Jump<Loc>),
     #[byte(tag = 0x21)]
+    /// Skips an instruction.
     Skip(Jump<Loc>),
     #[byte(tag = 0x22)]
+    /// Evaluates a conditional expression.
     Conditional(Conditional<Loc>),
     #[byte(tag = 0x23)]
+    /// Constructs a new object.
     Construct { arg_count: u8, class: ClassIndex },
     #[byte(tag = 0x24)]
+    /// Invokes a static method.
     InvokeStatic {
         exit: Jump<Loc>,
         line: u16,
@@ -95,6 +133,7 @@ pub enum Instr<Loc = Offset> {
         flags: InvokeFlags,
     },
     #[byte(tag = 0x25)]
+    /// Invokes a virtual method.
     InvokeVirtual {
         exit: Jump<Loc>,
         line: u16,
@@ -102,140 +141,207 @@ pub enum Instr<Loc = Offset> {
         flags: InvokeFlags,
     },
     #[byte(tag = 0x26)]
+    /// Marks the end of parameters for a method invocation.
     ParamEnd,
     #[byte(tag = 0x27)]
+    /// Returns from the current method.
     Return,
     #[byte(tag = 0x28)]
+    /// Accesses a field of a struct.
     StructField(FieldIndex),
     #[byte(tag = 0x29)]
+    /// Pushes a context onto the stack.
     Context(Jump<Loc>),
     #[byte(tag = 0x2A)]
+    /// Checks if two values are equal.
     Equals(TypeIndex),
     #[byte(tag = 0x2B)]
+    /// Checks if a reference string is equal to a string.
     RefStringEqualsString(TypeIndex),
     #[byte(tag = 0x2C)]
+    /// Checks if a string is equal to a reference string.
     StringEqualsRefString(TypeIndex),
     #[byte(tag = 0x2D)]
+    /// Checks if two values are not equal.
     NotEquals(TypeIndex),
     #[byte(tag = 0x2E)]
+    /// Checks if a reference string is not equal to a string.
     RefStringNotEqualsString(TypeIndex),
     #[byte(tag = 0x2F)]
+    /// Checks if a string is not equal to a reference string.
     StringNotEqualsRefString(TypeIndex),
     #[byte(tag = 0x30)]
+    /// Allocates a new object.
     New(ClassIndex),
     #[byte(tag = 0x31)]
+    /// Deletes an object.
     Delete,
     #[byte(tag = 0x32)]
+    /// Pushes a reference to `this` onto the stack.
     This,
     #[byte(tag = 0x33)]
+    /// Profiling instruction.
     Profile(Box<Profile>),
     #[byte(tag = 0x34)]
+    /// Clears an array.
     ArrayClear(TypeIndex),
     #[byte(tag = 0x35)]
+    /// Gets the size of an array.
     ArraySize(TypeIndex),
     #[byte(tag = 0x36)]
+    /// Resizes an array.
     ArrayResize(TypeIndex),
     #[byte(tag = 0x37)]
+    /// Finds the first occurrence of an element in an array.
     ArrayFindFirst(TypeIndex),
     #[byte(tag = 0x38)]
+    /// Fast lookup for the first occurrence in an array.
     ArrayFindFirstFast(TypeIndex),
     #[byte(tag = 0x39)]
+    /// Finds the last occurrence of an element in an array.
     ArrayFindLast(TypeIndex),
     #[byte(tag = 0x3A)]
+    /// Fast lookup for the last occurrence in an array.
     ArrayFindLastFast(TypeIndex),
     #[byte(tag = 0x3B)]
+    /// Checks if an array contains a specific element.
     ArrayContains(TypeIndex),
     #[byte(tag = 0x3C)]
+    /// Fast check for element presence in an array.
     ArrayContainsFast(TypeIndex),
     #[byte(tag = 0x3D)]
+    /// Counts the occurrences of an element in an array.
     ArrayCount(TypeIndex),
     #[byte(tag = 0x3E)]
+    /// Fast count of an element in an array.
     ArrayCountFast(TypeIndex),
     #[byte(tag = 0x3F)]
+    /// Pushes an element to the end of an array.
     ArrayPush(TypeIndex),
     #[byte(tag = 0x40)]
+    /// Pops an element from the end of an array.
     ArrayPop(TypeIndex),
     #[byte(tag = 0x41)]
+    /// Inserts an element into an array at a specific index.
     ArrayInsert(TypeIndex),
     #[byte(tag = 0x42)]
+    /// Removes an element from an array.
     ArrayRemove(TypeIndex),
     #[byte(tag = 0x43)]
+    /// Fast removal of an element from an array.
     ArrayRemoveFast(TypeIndex),
     #[byte(tag = 0x44)]
+    /// Grows the capacity of an array.
     ArrayGrow(TypeIndex),
     #[byte(tag = 0x45)]
+    /// Erases an element from an array at a specific index.
     ArrayErase(TypeIndex),
     #[byte(tag = 0x46)]
+    /// Fast erase of an element from an array.
     ArrayEraseFast(TypeIndex),
     #[byte(tag = 0x47)]
+    /// Gets the last element of an array.
     ArrayLast(TypeIndex),
     #[byte(tag = 0x48)]
+    /// Gets an element from an array at a specific index.
     ArrayElement(TypeIndex),
     #[byte(tag = 0x49)]
+    /// Sorts an array.
     ArraySort(TypeIndex),
     #[byte(tag = 0x4A)]
+    /// Sorts an array using a predicate.
     ArraySortByPredicate(TypeIndex),
     #[byte(tag = 0x4B)]
+    /// Gets the size of a static array.
     StaticArraySize(TypeIndex),
     #[byte(tag = 0x4C)]
+    /// Finds the first occurrence of an element in a static array.
     StaticArrayFindFirst(TypeIndex),
     #[byte(tag = 0x4D)]
+    /// Fast lookup for the first occurrence in a static array.
     StaticArrayFindFirstFast(TypeIndex),
     #[byte(tag = 0x4E)]
+    /// Finds the last occurrence of an element in a static array.
     StaticArrayFindLast(TypeIndex),
     #[byte(tag = 0x4F)]
+    /// Fast lookup for the last occurrence in a static array.
     StaticArrayFindLastFast(TypeIndex),
     #[byte(tag = 0x50)]
+    /// Checks if a static array contains a specific element.
     StaticArrayContains(TypeIndex),
     #[byte(tag = 0x51)]
+    /// Fast check for element presence in a static array.
     StaticArrayContainsFast(TypeIndex),
     #[byte(tag = 0x52)]
+    /// Counts the occurrences of an element in a static array.
     StaticArrayCount(TypeIndex),
     #[byte(tag = 0x53)]
+    /// Fast count of an element in a static array.
     StaticArrayCountFast(TypeIndex),
     #[byte(tag = 0x54)]
+    /// Gets the last element of a static array.
     StaticArrayLast(TypeIndex),
     #[byte(tag = 0x55)]
+    /// Gets an element from a static array at a specific index.
     StaticArrayElement(TypeIndex),
     #[byte(tag = 0x56)]
+    /// Converts a reference to a boolean.
     RefToBool,
     #[byte(tag = 0x57)]
+    /// Converts a weak reference to a boolean.
     WeakRefToBool,
     #[byte(tag = 0x58)]
+    /// Converts an enum value to a 32-bit integer.
     EnumToI32 { enum_type: TypeIndex, size: u8 },
     #[byte(tag = 0x59)]
+    /// Converts a 32-bit integer to an enum value.
     I32ToEnum { enum_type: TypeIndex, size: u8 },
     #[byte(tag = 0x5A)]
+    /// Performs a dynamic cast.
     DynamicCast { class: ClassIndex, is_weak: bool },
     #[byte(tag = 0x5B)]
+    /// Converts a value to a string.
     ToString(TypeIndex),
     #[byte(tag = 0x5C)]
+    /// Converts a value to a variant.
     ToVariant(TypeIndex),
     #[byte(tag = 0x5D)]
+    /// Extracts a value from a variant.
     FromVariant(TypeIndex),
     #[byte(tag = 0x5E)]
+    /// Checks if a variant is defined.
     VariantIsDefined,
     #[byte(tag = 0x5F)]
+    /// Checks if a variant contains a reference.
     VariantIsRef,
     #[byte(tag = 0x60)]
+    /// Checks if a variant contains an array.
     VariantIsArray,
     #[byte(tag = 0x61)]
+    /// Gets the type name of a variant.
     VariantTypeName,
     #[byte(tag = 0x62)]
+    /// Converts a variant to a string.
     VariantToString,
     #[byte(tag = 0x63)]
+    /// Converts a weak reference to a strong reference.
     WeakRefToRef,
     #[byte(tag = 0x64)]
+    /// Converts a strong reference to a weak reference.
     RefToWeakRef,
     #[byte(tag = 0x65)]
+    /// Pushes a null weak reference onto the stack.
     WeakRefNull,
     #[byte(tag = 0x66)]
+    /// Gets a reference to a value.
     AsRef(TypeIndex),
     #[byte(tag = 0x67)]
+    /// Dereferences a reference.
     Deref(TypeIndex),
 }
 
 impl<L> Instr<L> {
+    /// virtual_size
     pub fn virtual_size(&self) -> u16 {
         let op_size = match self {
             Instr::Breakpoint(_) => 19,
@@ -346,6 +452,7 @@ impl<L> Instr<L> {
         1 + op_size
     }
 
+    /// map_labels
     pub fn map_labels(self, f: impl Fn(L) -> Option<Offset>) -> Option<Instr> {
         let res = match self {
             Instr::Nop => Instr::Nop,
@@ -639,12 +746,14 @@ impl<L: fmt::Display> fmt::Display for Instr<L> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents an unconditional jump instruction.
 pub struct Jump<Loc> {
     target: Loc,
 }
 
 impl<Loc> Jump<Loc> {
     #[inline]
+    /// new
     pub fn new(target: Loc) -> Self {
         Jump { target }
     }
@@ -652,17 +761,20 @@ impl<Loc> Jump<Loc> {
 
 impl Jump<Offset> {
     #[inline]
+    /// new_with_offset
     pub fn new_with_offset(target: Offset) -> Self {
         Jump { target: target - 3 }
     }
 
     #[inline]
+    /// target
     pub fn target(&self) -> Offset {
         self.target + 3
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a conditional jump instruction.
 pub struct Conditional<Loc> {
     false_label: Loc,
     exit: Loc,
@@ -670,6 +782,7 @@ pub struct Conditional<Loc> {
 
 impl<Loc> Conditional<Loc> {
     #[inline]
+    /// new
     pub fn new(false_label: Loc, exit: Loc) -> Self {
         Conditional { false_label, exit }
     }
@@ -677,6 +790,7 @@ impl<Loc> Conditional<Loc> {
 
 impl Conditional<Offset> {
     #[inline]
+    /// new_with_offset
     pub fn new_with_offset(false_label: Offset, exit: Offset) -> Self {
         Conditional {
             false_label: false_label - 3,
@@ -685,17 +799,20 @@ impl Conditional<Offset> {
     }
 
     #[inline]
+    /// false_label
     pub fn false_label(&self) -> Offset {
         self.false_label + 3
     }
 
     #[inline]
+    /// exit
     pub fn exit(&self) -> Offset {
         self.exit + 5
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents the start of a switch statement.
 pub struct Switch<Loc> {
     expr_type: TypeIndex,
     first_case: Loc,
@@ -703,6 +820,7 @@ pub struct Switch<Loc> {
 
 impl<Loc> Switch<Loc> {
     #[inline]
+    /// new
     pub fn new(expr_type: TypeIndex, first_case: Loc) -> Self {
         Switch {
             expr_type,
@@ -713,6 +831,7 @@ impl<Loc> Switch<Loc> {
 
 impl Switch<Offset> {
     #[inline]
+    /// new_with_offset
     pub fn new_with_offset(expr_type: TypeIndex, first_case: Offset) -> Self {
         Switch {
             expr_type,
@@ -721,12 +840,14 @@ impl Switch<Offset> {
     }
 
     #[inline]
+    /// first_case
     pub fn first_case(&self) -> Offset {
         self.first_case + 11
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a label within a switch statement.
 pub struct SwitchLabel<Loc> {
     next_case: Loc,
     body: Loc,
@@ -734,6 +855,7 @@ pub struct SwitchLabel<Loc> {
 
 impl<Loc> SwitchLabel<Loc> {
     #[inline]
+    /// new
     pub fn new(next_case: Loc, body: Loc) -> Self {
         SwitchLabel { next_case, body }
     }
@@ -741,6 +863,7 @@ impl<Loc> SwitchLabel<Loc> {
 
 impl SwitchLabel<Offset> {
     #[inline]
+    /// new_with_offset
     pub fn new_with_offset(next_case: Offset, body: Offset) -> Self {
         SwitchLabel {
             next_case: next_case - 3,
@@ -749,17 +872,20 @@ impl SwitchLabel<Offset> {
     }
 
     #[inline]
+    /// next_case
     pub fn next_case(&self) -> Offset {
         self.next_case + 3
     }
 
     #[inline]
+    /// body
     pub fn body(&self) -> Offset {
         self.body + 5
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a breakpoint instruction.
 pub struct Breakpoint {
     line: u16,
     line_start: u32,
@@ -770,6 +896,7 @@ pub struct Breakpoint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Represents a profiling instruction.
 pub struct Profile {
     #[byte(ctx = Prefixed(ctx))]
     function: Vec<u8>,
@@ -777,6 +904,7 @@ pub struct Profile {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, TryRead, TryWrite, Measure)]
+/// Represents an offset location in the bytecode.
 pub struct Offset {
     value: i16,
 }
@@ -831,15 +959,18 @@ impl fmt::Display for Offset {
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, TryRead, TryWrite, Measure)]
+/// Flags associated with an invocation instruction.
 pub struct InvokeFlags(u16);
 
 impl InvokeFlags {
     #[inline]
+    /// set_is_rvalue_ref
     pub fn set_is_rvalue_ref(&mut self, nth: u8) {
         self.0 |= 1 << nth;
     }
 
     #[inline]
+    /// is_rvalue_ref
     pub fn is_rvalue_ref(&self, nth: u8) -> bool {
         self.0 & (1 << nth) != 0
     }

--- a/crates/io/src/instr.rs
+++ b/crates/io/src/instr.rs
@@ -341,7 +341,7 @@ pub enum Instr<Loc = Offset> {
 }
 
 impl<L> Instr<L> {
-    /// virtual_size
+    /// Gets the `virtual_size` of this definition.
     pub fn virtual_size(&self) -> u16 {
         let op_size = match self {
             Instr::Breakpoint(_) => 19,
@@ -452,7 +452,7 @@ impl<L> Instr<L> {
         1 + op_size
     }
 
-    /// map_labels
+    /// Applies a mapping function to labels.
     pub fn map_labels(self, f: impl Fn(L) -> Option<Offset>) -> Option<Instr> {
         let res = match self {
             Instr::Nop => Instr::Nop,
@@ -753,7 +753,7 @@ pub struct Jump<Loc> {
 
 impl<Loc> Jump<Loc> {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(target: Loc) -> Self {
         Jump { target }
     }
@@ -761,13 +761,13 @@ impl<Loc> Jump<Loc> {
 
 impl Jump<Offset> {
     #[inline]
-    /// new_with_offset
+    /// Creates a new instance with a given offset.
     pub fn new_with_offset(target: Offset) -> Self {
         Jump { target: target - 3 }
     }
 
     #[inline]
-    /// target
+    /// Gets the `target` of this definition.
     pub fn target(&self) -> Offset {
         self.target + 3
     }
@@ -782,7 +782,7 @@ pub struct Conditional<Loc> {
 
 impl<Loc> Conditional<Loc> {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(false_label: Loc, exit: Loc) -> Self {
         Conditional { false_label, exit }
     }
@@ -790,7 +790,7 @@ impl<Loc> Conditional<Loc> {
 
 impl Conditional<Offset> {
     #[inline]
-    /// new_with_offset
+    /// Creates a new instance with a given offset.
     pub fn new_with_offset(false_label: Offset, exit: Offset) -> Self {
         Conditional {
             false_label: false_label - 3,
@@ -799,13 +799,13 @@ impl Conditional<Offset> {
     }
 
     #[inline]
-    /// false_label
+    /// Gets the `false_label` of this definition.
     pub fn false_label(&self) -> Offset {
         self.false_label + 3
     }
 
     #[inline]
-    /// exit
+    /// Gets the `exit` of this definition.
     pub fn exit(&self) -> Offset {
         self.exit + 5
     }
@@ -820,7 +820,7 @@ pub struct Switch<Loc> {
 
 impl<Loc> Switch<Loc> {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(expr_type: TypeIndex, first_case: Loc) -> Self {
         Switch {
             expr_type,
@@ -831,7 +831,7 @@ impl<Loc> Switch<Loc> {
 
 impl Switch<Offset> {
     #[inline]
-    /// new_with_offset
+    /// Creates a new instance with a given offset.
     pub fn new_with_offset(expr_type: TypeIndex, first_case: Offset) -> Self {
         Switch {
             expr_type,
@@ -840,7 +840,7 @@ impl Switch<Offset> {
     }
 
     #[inline]
-    /// first_case
+    /// Gets the `first_case` of this definition.
     pub fn first_case(&self) -> Offset {
         self.first_case + 11
     }
@@ -855,7 +855,7 @@ pub struct SwitchLabel<Loc> {
 
 impl<Loc> SwitchLabel<Loc> {
     #[inline]
-    /// new
+    /// Creates a new instance.
     pub fn new(next_case: Loc, body: Loc) -> Self {
         SwitchLabel { next_case, body }
     }
@@ -863,7 +863,7 @@ impl<Loc> SwitchLabel<Loc> {
 
 impl SwitchLabel<Offset> {
     #[inline]
-    /// new_with_offset
+    /// Creates a new instance with a given offset.
     pub fn new_with_offset(next_case: Offset, body: Offset) -> Self {
         SwitchLabel {
             next_case: next_case - 3,
@@ -872,13 +872,13 @@ impl SwitchLabel<Offset> {
     }
 
     #[inline]
-    /// next_case
+    /// Gets the `next_case` of this definition.
     pub fn next_case(&self) -> Offset {
         self.next_case + 3
     }
 
     #[inline]
-    /// body
+    /// Gets the function body.
     pub fn body(&self) -> Offset {
         self.body + 5
     }
@@ -964,13 +964,13 @@ pub struct InvokeFlags(u16);
 
 impl InvokeFlags {
     #[inline]
-    /// set_is_rvalue_ref
+    /// Sets whether the nth argument is an rvalue reference.
     pub fn set_is_rvalue_ref(&mut self, nth: u8) {
         self.0 |= 1 << nth;
     }
 
     #[inline]
-    /// is_rvalue_ref
+    /// Checks if the nth argument is an rvalue reference.
     pub fn is_rvalue_ref(&self, nth: u8) -> bool {
         self.0 & (1 << nth) != 0
     }


### PR DESCRIPTION
Add missing documentation to public types in the io crate, particularly the `Instr` enum variants.

---
*PR created automatically by Jules for task [8738866984925480858](https://jules.google.com/task/8738866984925480858) started by @jac3km4*