### PR TITLE
Fix formatter moving trailing comments outside function body

### DIFF
--- a/crates/syntax/ast/src/visitor.rs
+++ b/crates/syntax/ast/src/visitor.rs
@@ -418,4 +418,9 @@ impl NodeId {
     pub fn condition<K: AstKind>(condition: &Pattern<'_, K>) -> Self {
         Self(ptr::from_ref(condition).cast())
     }
+
+    #[inline]
+    pub fn block<K: AstKind>(block: &Block<'_, K>) -> Self {
+        Self(ptr::from_ref(block).cast())
+    }
 }

--- a/crates/syntax/formatter/src/lib.rs
+++ b/crates/syntax/formatter/src/lib.rs
@@ -348,7 +348,11 @@ impl<K: AstKind> Formattable for Block<'_, K> {
             writeln!(f, "{}", stmt.as_wrapped().as_fmt(ctx.bump(1)))?;
         }
         // Render trailing comments (after last statement, before closing brace)
-        write!(f, "{}", ctx.node_prefix(NodeId::block(self), Some(ctx.bump(1).ws())))?;
+        write!(
+            f,
+            "{}",
+            ctx.node_prefix(NodeId::block(self), Some(ctx.bump(1).ws()))
+        )?;
         write!(f, "{}}}", ctx.ws())
     }
 }
@@ -1655,8 +1659,9 @@ impl<'src> AstVisitor<'src, WithSpan> for PrefixCollector<'_, 'src> {
         }
         if !trailing_comments.is_empty() {
             // Store trailing comments with the block's ID
-            self.prefixes.entry(NodeId::block(block))
-                .or_insert_with(Vec::new)
+            self.prefixes
+                .entry(NodeId::block(block))
+                .or_default()
                 .extend(trailing_comments);
         }
 

--- a/crates/syntax/formatter/src/lib.rs
+++ b/crates/syntax/formatter/src/lib.rs
@@ -1619,46 +1619,59 @@ impl<'src> AstVisitor<'src, WithSpan> for PrefixCollector<'_, 'src> {
             .iter()
             .try_for_each(|stmt| self.visit_stmt(stmt))?;
 
-        // Collect trailing comments inside the block (after last statement, before closing brace)
-        // Use a heuristic: collect comments that appear immediately after the last statement,
-        // stopping at the first double-newline (blank line) which likely indicates the block end
-        // Also handle empty blocks (no statements but may have comments)
+        // Collect trailing comments inside the block (after last statement, before
+        // closing brace). The remainder stream contains only LineFeed/comment tokens
+        // (whitespace/comment partition), so we cannot see a closing brace token to
+        // stop on. To avoid stealing comments and blank-line separators that belong
+        // to the surrounding scope, we use two guards:
+        //
+        // 1. Skip empty blocks. With no last statement, the loop would walk forward
+        //    past the closing brace into sibling/parent scope and capture comments
+        //    that belong elsewhere (eg. a top-level comment after the function).
+        //
+        // 2. Stop on a blank line (two consecutive LineFeeds). A blank line after a
+        //    comment-or-statement marks the end of the trailing-comment region, even
+        //    without a brace token. This bounds the walk inside the current block.
+        //
+        // 3. Buffer LineFeeds in `pending` and only commit consumption to
+        //    `self.remainder` when a comment actually follows. If no comment is seen,
+        //    blank-line separators between sibling statements remain in
+        //    `self.remainder` and are picked up by the next stmt's visit_node, which
+        //    handles blank-line preservation between siblings.
+        if block.stmts.is_empty() {
+            return Ok(());
+        }
+
         let mut trailing_comments = vec![];
         let mut consecutive_linefeeds = 0;
-        let mut seen_comment = false;
+        let mut pending = self.remainder;
 
-        // Process tokens after the last statement (or start of block if empty): linefeeds and comments
-        while let [(fst, _span), rest @ ..] = self.remainder {
+        while let [(fst, _span), rest @ ..] = pending {
             match fst {
                 Token::LineComment(comment) => {
                     trailing_comments.push(Prefix::LineComment(comment));
                     consecutive_linefeeds = 0;
-                    seen_comment = true;
+                    pending = rest;
                     self.remainder = rest;
                 }
                 Token::BlockComment(comment) => {
                     trailing_comments.push(Prefix::BlockComment(comment));
                     consecutive_linefeeds = 0;
-                    seen_comment = true;
+                    pending = rest;
                     self.remainder = rest;
                 }
                 Token::LineFeed => {
                     consecutive_linefeeds += 1;
-                    // Only stop on blank line if we've already seen at least one comment
-                    // This prevents stopping at blank lines BEFORE the first comment
-                    if seen_comment && consecutive_linefeeds >= 2 {
+                    if consecutive_linefeeds >= 2 {
                         break;
                     }
-                    self.remainder = rest;
+                    pending = rest;
                 }
-                _ => {
-                    // Stop when we hit a non-comment, non-linefeed token
-                    break;
-                }
+                _ => break,
             }
         }
+
         if !trailing_comments.is_empty() {
-            // Store trailing comments with the block's ID
             self.prefixes
                 .entry(NodeId::block(block))
                 .or_default()

--- a/crates/syntax/formatter/src/lib.rs
+++ b/crates/syntax/formatter/src/lib.rs
@@ -1621,6 +1621,7 @@ impl<'src> AstVisitor<'src, WithSpan> for PrefixCollector<'_, 'src> {
         // Also handle empty blocks (no statements but may have comments)
         let mut trailing_comments = vec![];
         let mut consecutive_linefeeds = 0;
+        let mut seen_comment = false;
 
         // Process tokens after the last statement (or start of block if empty): linefeeds and comments
         while let [(fst, _span), rest @ ..] = self.remainder {
@@ -1628,18 +1629,20 @@ impl<'src> AstVisitor<'src, WithSpan> for PrefixCollector<'_, 'src> {
                 Token::LineComment(comment) => {
                     trailing_comments.push(Prefix::LineComment(comment));
                     consecutive_linefeeds = 0;
+                    seen_comment = true;
                     self.remainder = rest;
                 }
                 Token::BlockComment(comment) => {
                     trailing_comments.push(Prefix::BlockComment(comment));
                     consecutive_linefeeds = 0;
+                    seen_comment = true;
                     self.remainder = rest;
                 }
                 Token::LineFeed => {
                     consecutive_linefeeds += 1;
-                    // Stop if we hit a blank line (two consecutive linefeeds)
-                    // This likely means we've reached the closing brace or end of block
-                    if consecutive_linefeeds >= 2 {
+                    // Only stop on blank line if we've already seen at least one comment
+                    // This prevents stopping at blank lines BEFORE the first comment
+                    if seen_comment && consecutive_linefeeds >= 2 {
                         break;
                     }
                     self.remainder = rest;

--- a/crates/syntax/formatter/src/lib.rs
+++ b/crates/syntax/formatter/src/lib.rs
@@ -347,6 +347,8 @@ impl<K: AstKind> Formattable for Block<'_, K> {
         for stmt in &self.stmts[..] {
             writeln!(f, "{}", stmt.as_wrapped().as_fmt(ctx.bump(1)))?;
         }
+        // Render trailing comments (after last statement, before closing brace)
+        write!(f, "{}", ctx.node_prefix(NodeId::block(self), Some(ctx.bump(1).ws())))?;
         write!(f, "{}}}", ctx.ws())
     }
 }
@@ -1611,7 +1613,51 @@ impl<'src> AstVisitor<'src, WithSpan> for PrefixCollector<'_, 'src> {
         block
             .stmts
             .iter()
-            .try_for_each(|stmt| self.visit_stmt(stmt))
+            .try_for_each(|stmt| self.visit_stmt(stmt))?;
+
+        // Collect trailing comments inside the block (after last statement, before closing brace)
+        // Use a heuristic: collect comments that appear immediately after the last statement,
+        // stopping at the first double-newline (blank line) which likely indicates the block end
+        // Also handle empty blocks (no statements but may have comments)
+        let mut trailing_comments = vec![];
+        let mut consecutive_linefeeds = 0;
+
+        // Process tokens after the last statement (or start of block if empty): linefeeds and comments
+        while let [(fst, _span), rest @ ..] = self.remainder {
+            match fst {
+                Token::LineComment(comment) => {
+                    trailing_comments.push(Prefix::LineComment(comment));
+                    consecutive_linefeeds = 0;
+                    self.remainder = rest;
+                }
+                Token::BlockComment(comment) => {
+                    trailing_comments.push(Prefix::BlockComment(comment));
+                    consecutive_linefeeds = 0;
+                    self.remainder = rest;
+                }
+                Token::LineFeed => {
+                    consecutive_linefeeds += 1;
+                    // Stop if we hit a blank line (two consecutive linefeeds)
+                    // This likely means we've reached the closing brace or end of block
+                    if consecutive_linefeeds >= 2 {
+                        break;
+                    }
+                    self.remainder = rest;
+                }
+                _ => {
+                    // Stop when we hit a non-comment, non-linefeed token
+                    break;
+                }
+            }
+        }
+        if !trailing_comments.is_empty() {
+            // Store trailing comments with the block's ID
+            self.prefixes.entry(NodeId::block(block))
+                .or_insert_with(Vec::new)
+                .extend(trailing_comments);
+        }
+
+        Ok(())
     }
 
     fn visit_default(&mut self, stmts: &[Spanned<SourceStmt<'src>>]) -> Result<(), Self::Error> {

--- a/crates/syntax/formatter/tests/data/trailing-comments-in-block.reds
+++ b/crates/syntax/formatter/tests/data/trailing-comments-in-block.reds
@@ -1,0 +1,5 @@
+func Test() {
+  1 + 2;
+  // Comment 1
+  // Comment 2
+}

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@commented.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@commented.reds.snap
@@ -2,6 +2,7 @@
 source: crates/syntax/formatter/tests/formatted.rs
 expression: module
 input_file: crates/syntax/formatter/tests/data/commented.reds
-snapshot_kind: text
 ---
+
+
 // the entire file is commented out

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@control-flow.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@control-flow.reds.snap
@@ -11,16 +11,15 @@ func Test() {
     && false
     && true
     && false {
+    // trailing comment
   } else if false {
     FTLog("a");
   } else {
     FTLog("b");
   }
-
   if true {
     FTLog("c");
   }
-
   while true
     && false
     && true
@@ -29,11 +28,9 @@ func Test() {
     && false {
     FTLog("d");
   }
-
   while false {
     FTLog("e");
   }
-
   for x in [
     "lorem",
     "ipsum",
@@ -57,7 +54,6 @@ func Test() {
   ] {
     FTLog(x);
   }
-
   switch 1 {
     case 0:
       FTLog("f");
@@ -66,7 +62,6 @@ func Test() {
     default:
       FTLog("h");
   }
-
   let result;
   switch [1, 2, 3] {
     case let [..,a, b, c]:
@@ -81,11 +76,9 @@ func Test() {
     default:
       result = 0;
   }
-
   if let [..,a, b, c] = [1, 2, 3] {
     result = a;
   }
-
   if let [
     one,
     two,
@@ -105,10 +98,8 @@ func Test() {
     sixteen
   ] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] {
   }
-
   if let Class { fieldA } = new Class() {
   }
-
   if let Class {
     fieldA,
     fieldB,
@@ -123,11 +114,9 @@ func Test() {
     fieldK
   } = new Class() {
   }
-
   for y in [1, 2, 3] {
     FTLog(s"f: \(y)");
   }
-
   let f1 = (a) -> a;
   let f2 = (a) -> {
     return a;
@@ -148,5 +137,3 @@ class Class {
   let fieldJ: Double;
   let fieldK: String;
 }
-
-// trailing comment

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@control-flow.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@control-flow.reds.snap
@@ -3,6 +3,7 @@ source: crates/syntax/formatter/tests/formatted.rs
 expression: module
 input_file: crates/syntax/formatter/tests/data/control-flow.reds
 ---
+
 func Test() {
   if true
     && false

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@control-flow.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@control-flow.reds.snap
@@ -3,7 +3,6 @@ source: crates/syntax/formatter/tests/formatted.rs
 expression: module
 input_file: crates/syntax/formatter/tests/data/control-flow.reds
 ---
-
 func Test() {
   if true
     && false
@@ -11,15 +10,16 @@ func Test() {
     && false
     && true
     && false {
-    // trailing comment
   } else if false {
     FTLog("a");
   } else {
     FTLog("b");
   }
+
   if true {
     FTLog("c");
   }
+
   while true
     && false
     && true
@@ -28,9 +28,11 @@ func Test() {
     && false {
     FTLog("d");
   }
+
   while false {
     FTLog("e");
   }
+
   for x in [
     "lorem",
     "ipsum",
@@ -54,6 +56,7 @@ func Test() {
   ] {
     FTLog(x);
   }
+
   switch 1 {
     case 0:
       FTLog("f");
@@ -62,6 +65,7 @@ func Test() {
     default:
       FTLog("h");
   }
+
   let result;
   switch [1, 2, 3] {
     case let [..,a, b, c]:
@@ -76,9 +80,11 @@ func Test() {
     default:
       result = 0;
   }
+
   if let [..,a, b, c] = [1, 2, 3] {
     result = a;
   }
+
   if let [
     one,
     two,
@@ -98,8 +104,10 @@ func Test() {
     sixteen
   ] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] {
   }
+
   if let Class { fieldA } = new Class() {
   }
+
   if let Class {
     fieldA,
     fieldB,
@@ -114,9 +122,11 @@ func Test() {
     fieldK
   } = new Class() {
   }
+
   for y in [1, 2, 3] {
     FTLog(s"f: \(y)");
   }
+
   let f1 = (a) -> a;
   let f2 = (a) -> {
     return a;
@@ -137,3 +147,5 @@ class Class {
   let fieldJ: Double;
   let fieldK: String;
 }
+
+// trailing comment

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@module.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@module.reds.snap
@@ -68,6 +68,7 @@ func LongFunc1(
     4.0,
     "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore"
   );
+
   LongFunc2(
     LongFunc2(
       0,

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@module.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@module.reds.snap
@@ -2,7 +2,6 @@
 source: crates/syntax/formatter/tests/formatted.rs
 expression: module
 input_file: crates/syntax/formatter/tests/data/module.reds
-snapshot_kind: text
 ---
 module Test.Module
 

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@module.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@module.reds.snap
@@ -68,7 +68,6 @@ func LongFunc1(
     4.0,
     "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore"
   );
-
   LongFunc2(
     LongFunc2(
       0,

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@operators.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@operators.reds.snap
@@ -2,8 +2,8 @@
 source: crates/syntax/formatter/tests/formatted.rs
 expression: module
 input_file: crates/syntax/formatter/tests/data/operators.reds
-snapshot_kind: text
 ---
+
 func Test1() {
   let a = 1 * (2 + 3);
   let b = (4 + 5) * 6;

--- a/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@trailing-comments-in-block.reds.snap
+++ b/crates/syntax/formatter/tests/snapshots/formatted__formatted_files@trailing-comments-in-block.reds.snap
@@ -1,0 +1,11 @@
+---
+source: crates/syntax/formatter/tests/formatted.rs
+expression: module
+input_file: crates/syntax/formatter/tests/data/trailing-comments-in-block.reds
+---
+
+func Test() {
+  1 + 2;
+  // Comment 1
+  // Comment 2
+}


### PR DESCRIPTION
Comments after the last statement in a function body get moved to module level after formatting. The PrefixCollector associates comments with the AST node that follows them, but comments at the end of a block have no subsequent node, so they end up in the module-level remainder.

This adds trailing comment collection in visit_block() after visiting all statements, and renders them before the closing brace in Block::format(). A double-newline heuristic prevents over-collection of comments that belong to the next definition.

Fixes #184