### PR TITLE
Fail fast when compilation fails in the macOS launch script

### DIFF
--- a/assets/macos/archive/launch_modded.sh
+++ b/assets/macos/archive/launch_modded.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 # Compiles REDscript and launches the game.
+set -euo pipefail
 
 game_dir=$(dirname "$(readlink -f "$0")")
 
-"$game_dir/engine/tools/scc" -compile "$game_dir/r6/scripts"
-"$game_dir/Cyberpunk2077.app/Contents/MacOS/Cyberpunk2077"
+if ! "$game_dir/engine/tools/scc" -compile "$game_dir/r6/scripts"; then
+    message="REDscript compilation failed, the game was not launched. Check r6/logs/redscript_rCURRENT.log for details."
+    echo "$message" >&2
+    osascript -e "display alert \"REDscript\" message \"$message\" as critical" >/dev/null 2>&1 || true
+    exit 1
+fi
+
+open "$game_dir/Cyberpunk2077.app"

--- a/crates/scc/cli/src/main.rs
+++ b/crates/scc/cli/src/main.rs
@@ -47,6 +47,7 @@ fn run(r6_dir: &Path, args: Option<Arguments>) -> anyhow::Result<()> {
         .context("missing 'settings_add_script_path'")?;
     let compile = api.compile.context("missing 'compile'")?;
     let free_result = api.free_result.context("missing 'free_result'")?;
+    let get_success = api.get_success.context("missing 'get_success'")?;
 
     let root = c_path(r6_dir)?;
 
@@ -72,7 +73,12 @@ fn run(r6_dir: &Path, args: Option<Arguments>) -> anyhow::Result<()> {
         }
 
         let res = compile(settings);
+        let succeeded = !get_success(res).is_null();
         free_result(res);
+
+        if !succeeded {
+            std::process::exit(1);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Problem

On macOS, `launch_modded.sh` launches the game even when script compilation fails. Since `scc` always exited with code 0 (the compilation result was discarded), the script had no way to detect the failure — the game would silently start with the last successfully compiled `final.redscripts`, which is confusing when iterating on mods.

## Changes

- **`scc` CLI**: check the compilation result via `scc_get_success` and exit with code 1 on fatal errors (previously the result was freed without inspection and the exit code was always 0).
- **`launch_modded.sh`**: abort the launch when `scc` fails, print the error to stderr, and show a native alert dialog via `osascript` so failures are visible when the script is run outside a terminal. Also launch the game via `open` on the app bundle so it starts as a regular app rather than a child process of the shell, and add `set -euo pipefail`.

## Testing

Verified on a real install (GOG build 2.31, Apple Silicon, macOS 26.5.1):

- Clean `r6/scripts` → `scc` exits 0, game launches normally, mods applied (verified in-game).
- With a syntactically broken `.reds` present → `scc` exits 1, launch script prints the error, shows the alert dialog, and does not launch the game. `final.redscripts` is left untouched.