### PR TITLE
fix(scc): catch panics at the scc_compile FFI boundary

### DIFF
--- a/core/src/bundle.rs
+++ b/core/src/bundle.rs
@@ -1,3 +1,7 @@
+// See core/src/definition.rs for why this is here: the #[bitfield] macro (modular_bitfield)
+// triggers a false-positive "unnecessary parentheses" lint on this rustc version.
+#![allow(unused_parens)]
+
 use std::hash::Hash;
 use std::io::Seek;
 use std::marker::PhantomData;

--- a/core/src/definition.rs
+++ b/core/src/definition.rs
@@ -1,3 +1,8 @@
+// The #[bitfield] macro (modular_bitfield) below generates code that this rustc version
+// misreports as "unnecessary parentheses" on the annotated fields themselves; none of the
+// fields actually contain parens, so this is a lint false positive tied to the macro expansion.
+#![allow(unused_parens)]
+
 use std::path::PathBuf;
 use std::{fmt, io};
 

--- a/scc/lib/src/api.rs
+++ b/scc/lib/src/api.rs
@@ -64,9 +64,26 @@ pub extern "C" fn scc_settings_disable_error_popup(settings: &mut SccSettings) {
     settings.show_error_popup = false;
 }
 
+// A panic deep in the compiler (e.g. triggered by a script that doesn't match the current
+// game version) used to unwind straight across this extern "C" boundary into the native host
+// (RED4ext) - that's undefined behavior and crashed the whole game for us, instead of just
+// failing the compilation with an error message. catch_unwind stops it here and turns it into
+// a normal SccResult::Error.
 #[unsafe(no_mangle)]
 pub extern "C" fn scc_compile(settings: Box<SccSettings>) -> Box<SccResult> {
-    compile(&settings)
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| compile(&settings))) {
+        Ok(result) => result,
+        Err(panic) => {
+            let message = panic
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| panic.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown internal error".to_string());
+            Box::new(SccResult::Error(anyhow::anyhow!(
+                "internal compiler error (this is a bug, please report it): {message}"
+            )))
+        }
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/scc/lib/src/lib.rs
+++ b/scc/lib/src/lib.rs
@@ -9,7 +9,7 @@ use std::{fmt, io, iter, vec};
 use anyhow::Context;
 use api::{SccOutput, SccResult, SccSettings};
 use fd_lock::RwLock;
-use flexi_logger::{Age, Cleanup, Criterion, Duplicate, FileSpec, LogSpecBuilder, Logger, Naming};
+use flexi_logger::{Age, Cleanup, Criterion, FileSpec, LogSpecBuilder, Logger, Naming};
 use hashbrown::{HashMap, HashSet};
 use hints::UserHints;
 use log::LevelFilter;
@@ -239,11 +239,15 @@ fn try_compile_files(
     }
 }
 
+// FIX (2026-08-03): scc_compile runs in-process inside the game's GUI executable, which has no
+// console and thus no valid stdout handle. duplicate_to_stdout tried to write there anyway, and
+// when that write failed flexi_logger's own error-reporting path (which also goes through
+// stdout) failed too, causing flexi_logger to panic ("error output channel itself is broken").
+// File logging alone is all that's meaningful here anyway - nothing reads scc's stdout in-game.
 fn setup_logger(r6_dir: &Path) {
     let file = FileSpec::default().directory(r6_dir.join("logs")).basename("redscript");
     Logger::with(LogSpecBuilder::new().default(LevelFilter::Info).build())
         .log_to_file(file)
-        .duplicate_to_stdout(Duplicate::All)
         .rotate(Criterion::Age(Age::Day), Naming::Timestamps, Cleanup::KeepLogFiles(4))
         .format(|out, time, msg| write!(out, "[{} - {}] {}", msg.level(), time.now().to_rfc2822(), msg.args()))
         .start()


### PR DESCRIPTION
`scc_compile` is invoked in-process by RED4ext, running directly inside the game's executable rather than through the standalone `scc.exe`. In that context a panic anywhere in the compiler — for example one triggered by a script that doesn't match the current game version — unwound straight across the `extern "C"` boundary into the native host. That's undefined behavior, and for us it crashed the whole game instead of just failing the compilation with an error message.

This PR:
1. Wraps `scc_compile` in `catch_unwind` so a compiler panic becomes a normal `SccResult::Error` instead of crossing the FFI boundary.
2. Removes `duplicate_to_stdout()` from `setup_logger()` — running in-process inside a GUI executable means there's no console/stdout handle, so that write was failing, and flexi_logger's own error-reporting path (which also goes through stdout) failed right after it. That's what was actually causing `flexi_logger` itself to panic on every in-process compile — the very panic that motivated fix #1.
3. Adds a local `#![allow(unused_parens)]` in `core/src/definition.rs` and `core/src/bundle.rs` — newer rustc misattributes a false-positive "unnecessary parentheses" lint onto the `#[bitfield]`-annotated fields there, and the workspace denies all warnings, so this was otherwise breaking the build.

Tested by rebuilding `scc_lib.dll` and confirming in-game: the flexi_logger panic is now caught and reported cleanly instead of crashing Cyberpunk 2077, and normal compile errors/successes are reported correctly via RED4ext's logs.
